### PR TITLE
fix: return empty string instead of null when http request fails

### DIFF
--- a/BulletTrainClient.cs
+++ b/BulletTrainClient.cs
@@ -295,7 +295,7 @@ namespace BulletTrain
             {
                 Console.WriteLine("\nHTTP Request Exception Caught!");
                 Console.WriteLine("Message :{0} ", e.Message);
-                return null;
+                return string.Empty;
             }
         }
 

--- a/BulletTrainClient.cs
+++ b/BulletTrainClient.cs
@@ -67,7 +67,7 @@ namespace BulletTrain
                 }
                 else
                 {
-                    return JsonConvert.DeserializeObject<Identity>(json).flags;
+                    return JsonConvert.DeserializeObject<Identity>(json)?.flags;
                 }
             }
             catch (JsonException e)
@@ -122,7 +122,11 @@ namespace BulletTrain
                 string url = GetIdentitiesUrl(identity);
                 string json = await GetJSON(HttpMethod.Get, url);
 
-                List<Trait> traits = JsonConvert.DeserializeObject<Identity>(json).traits;
+                List<Trait> traits = JsonConvert.DeserializeObject<Identity>(json)?.traits;
+                if (traits == null)
+                {
+                    return null;
+                }
                 if (keys == null)
                 {
                     return traits;


### PR DESCRIPTION
this avoids unhandled ArgumentNullExceptions coming from Newtonsoft.JsonSerializer