### PR TITLE
fix: avoid null reference exceptions

### DIFF
--- a/BulletTrainClient.cs
+++ b/BulletTrainClient.cs
@@ -295,7 +295,7 @@ namespace BulletTrain
             {
                 Console.WriteLine("\nHTTP Request Exception Caught!");
                 Console.WriteLine("Message :{0} ", e.Message);
-                return null;
+                return string.Empty;
             }
         }
 

--- a/BulletTrainClient.cs
+++ b/BulletTrainClient.cs
@@ -84,6 +84,11 @@ namespace BulletTrain
         public async Task<bool> HasFeatureFlag(string featureId, string identity = null)
         {
             List<Flag> flags = await GetFeatureFlags(identity);
+            if (flags == null)
+            {
+                return false;
+            }
+
             foreach (Flag flag in flags)
             {
                 if (flag.GetFeature().GetName().Equals(featureId) && flag.IsEnabled())
@@ -101,6 +106,11 @@ namespace BulletTrain
         public async Task<string> GetFeatureValue(string featureId, string identity = null)
         {
             List<Flag> flags = await GetFeatureFlags(identity);
+            if (flags == null)
+            {
+                return null;
+            }
+
             foreach (Flag flag in flags)
             {
                 if (flag.GetFeature().GetName().Equals(featureId))
@@ -157,6 +167,10 @@ namespace BulletTrain
         public async Task<string> GetTrait(string identity, string key)
         {
             List<Trait> traits = await GetTraits(identity);
+            if (traits == null)
+            {
+                return null;
+            }
 
             foreach (Trait trait in traits)
             {
@@ -175,6 +189,10 @@ namespace BulletTrain
         public async Task<bool> GetBoolTrait(string identity, string key)
         {
             List<Trait> traits = await GetTraits(identity);
+            if (traits == null)
+            {
+                return false;
+            }
 
             foreach (Trait trait in traits)
             {
@@ -193,6 +211,10 @@ namespace BulletTrain
         public async Task<int> GetIntegerTrait(string identity, string key)
         {
             List<Trait> traits = await GetTraits(identity);
+            if (traits == null)
+            {
+                return 0;
+            }
 
             foreach (Trait trait in traits)
             {

--- a/BulletTrainClient.cs
+++ b/BulletTrainClient.cs
@@ -67,7 +67,7 @@ namespace BulletTrain
                 }
                 else
                 {
-                    return JsonConvert.DeserializeObject<Identity>(json).flags;
+                    return JsonConvert.DeserializeObject<Identity>(json)?.flags;
                 }
             }
             catch (JsonException e)
@@ -122,7 +122,11 @@ namespace BulletTrain
                 string url = GetIdentitiesUrl(identity);
                 string json = await GetJSON(HttpMethod.Get, url);
 
-                List<Trait> traits = JsonConvert.DeserializeObject<Identity>(json).traits;
+                List<Trait> traits = JsonConvert.DeserializeObject<Identity>(json)?.traits;
+                if (traits == null)
+                {
+                    return null;
+                }
                 if (keys == null)
                 {
                     return traits;


### PR DESCRIPTION
Return default values when NullReferenceException would be thrown