### PR TITLE
feat: return null instead of default value for value types

### DIFF
--- a/BulletTrainClient.cs
+++ b/BulletTrainClient.cs
@@ -81,12 +81,13 @@ namespace BulletTrain
         /// <summary>
         /// Check feature exists and is enabled optionally for a specific identity
         /// </summary>
-        public async Task<bool> HasFeatureFlag(string featureId, string identity = null)
+        /// <returns>Null if Bullet Train is unaccessible</returns>
+        public async Task<bool?> HasFeatureFlag(string featureId, string identity = null)
         {
             List<Flag> flags = await GetFeatureFlags(identity);
             if (flags == null)
             {
-                return false;
+                return null;
             }
 
             foreach (Flag flag in flags)
@@ -186,12 +187,13 @@ namespace BulletTrain
         /// <summary>
         /// Get boolean user trait for provided identity and trait key.
         /// </summary>
-        public async Task<bool> GetBoolTrait(string identity, string key)
+        /// <returns>Null if Bullet Train is unaccessible</returns>
+        public async Task<bool?> GetBoolTrait(string identity, string key)
         {
             List<Trait> traits = await GetTraits(identity);
             if (traits == null)
             {
-                return false;
+                return null;
             }
 
             foreach (Trait trait in traits)
@@ -208,12 +210,13 @@ namespace BulletTrain
         /// <summary>
         /// Get integer user trait for provided identity and trait key.
         /// </summary>
-        public async Task<int> GetIntegerTrait(string identity, string key)
+        /// <returns>Null if Bullet Train is unaccessible</returns>
+        public async Task<int?> GetIntegerTrait(string identity, string key)
         {
             List<Trait> traits = await GetTraits(identity);
             if (traits == null)
             {
-                return 0;
+                return null;
             }
 
             foreach (Trait trait in traits)

--- a/bullet-train-dotnet-client.csproj
+++ b/bullet-train-dotnet-client.csproj
@@ -6,7 +6,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PackageId>BulletTrain</PackageId>
     <Title>Bullet Train</Title>
-    <Version>2.1.7</Version>
+    <Version>2.2.0</Version>
     <Authors>ssg-luke</Authors>
     <Company>Bullet Train Ltd</Company>
     <PackageDescription>Client SDK for Flagsmith. Ship features with confidence using feature flags and remote config. Host yourself or use our hosted version at https://flagsmith.com/</PackageDescription>


### PR DESCRIPTION
This way anyone using this client can distinguish if BT was not responding or if the FF value was false / zero
Changing version to 2.2.0 as return types were updated