### PR TITLE
Use identity get request if no traits

### DIFF
--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -69,7 +69,24 @@ namespace Flagsmith.FlagsmithClientTest
             mockHttpClient.verifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
         }
         [Fact]
-        public async Task TestGetIdentityFlagsCallsApiWhenNoLocalEnvironmentNoTraits()
+        public async Task TestGetIdentityFlagsCallsGetApiWhenNoLocalEnvironmentNoTraits()
+        {
+            string identifier = "identifier";
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiIdentityResponse)
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var flags = (await flagsmithClientTest.GetIdentityFlags(identifier)).AllFlags();
+            Assert.True(flags[0].Enabled);
+            Assert.Equal("some-value", flags[0].Value);
+            Assert.Equal("some_feature", flags[0].GetFeatureName());
+            mockHttpClient.verifyHttpRequest(HttpMethod.Get, "/api/v1/identities/", Times.Once, new Dictionary<string, string> { { "identifier", identifier } });
+
+        }
+        [Fact]
+        public async Task TestGetIdentityFlagsCallsPostApiWhenNoLocalEnvironmentWithTraits()
         {
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
@@ -77,7 +94,10 @@ namespace Flagsmith.FlagsmithClientTest
                 Content = new StringContent(Fixtures.ApiIdentityResponse)
             });
             var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
-            var flags = (await flagsmithClientTest.GetIdentityFlags("identifier")).AllFlags();
+            var traits = new List<Trait> { new Trait("foo", "bar") };
+
+
+            var flags = (await flagsmithClientTest.GetIdentityFlags("identifier", traits)).AllFlags();
             Assert.True(flags[0].Enabled);
             Assert.Equal("some-value", flags[0].Value);
             Assert.Equal("some_feature", flags[0].GetFeatureName());

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -208,8 +208,20 @@ namespace Flagsmith
             try
             {
                 string url = ApiUrl.AppendPath("identities");
-                var jsonBody = JsonConvert.SerializeObject(new { identifier = identity, traits = traits ?? new List<Trait>() });
-                string jsonResponse = await GetJSON(HttpMethod.Post, url, body: jsonBody);
+                string jsonBody;
+                string jsonResponse;
+
+                if (traits != null && traits.Count > 0)
+                {
+                    jsonBody = JsonConvert.SerializeObject(new { identifier = identity, traits = traits ?? new List<Trait>() });
+                    jsonResponse = await GetJSON(HttpMethod.Post, url, body: jsonBody);
+                }
+                else
+                {
+                    url += $"?identifier={identity}";
+                    jsonResponse = await GetJSON(HttpMethod.Get, url);
+                }
+
                 var flags = JsonConvert.DeserializeObject<Identity>(jsonResponse)?.flags;
                 return Flags.FromApiFlag(_AnalyticsProcessor, DefaultFlagHandler, flags);
             }


### PR DESCRIPTION
If no traits are provided when requesting the flags for an identity, we should use a GET request instead of a POST request. 

Given the option now to cache GET identities and GET flags requests, this adds important functionality so that requests will use the cache if no traits are provided. 