### PR TITLE
fix: ensure environment is retrieved on startup

### DIFF
--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -92,6 +92,7 @@ namespace Flagsmith
                 _analyticsProcessor = new AnalyticsProcessor(this._httpClient, EnvironmentKey, ApiUrl, Logger, CustomHeaders);
             if (EnableClientSideEvaluation)
             {
+                this.GetAndUpdateEnvironmentFromApi().Wait();
                 _pollingManager = new PollingManager(GetAndUpdateEnvironmentFromApi, EnvironmentRefreshIntervalSeconds);
                 _ = _pollingManager.StartPoll();
             }

--- a/Flagsmith.FlagsmithClient/PollingManager.cs
+++ b/Flagsmith.FlagsmithClient/PollingManager.cs
@@ -11,7 +11,7 @@ namespace Flagsmith
         Func<Task> _CallBack;
         int _Interval;
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="callBack">Awaitable function that will be polled.</param>
         /// <param name="intervalSeconds">Total delay in seconds between continous exection of callback.</param>
@@ -29,8 +29,8 @@ namespace Flagsmith
             _CancellationTokenSource.Token.ThrowIfCancellationRequested();
             while (true)
             {
-                await _CallBack.Invoke();
                 await Task.Delay(_Interval, _CancellationTokenSource.Token);
+                await _CallBack.Invoke();
                 if (_CancellationTokenSource.Token.IsCancellationRequested)
                     break;
             }


### PR DESCRIPTION
Ensures that, when the client is run in local evaluation mode, the environment is retrieved synchronously on the initialisation of the client. 

This avoids issues where external requests are made to retrieve the flags from the Flagsmith API because the checks in the SDK to determine how to evaluate the flags rely on the existence of the local environment, not the `enableLocalEvaluation` attribute. 