### PR TITLE
Fix cache initialisation that was some kind of circular reference.

### DIFF
--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -281,14 +281,14 @@ namespace Flagsmith.FlagsmithClientTest
                 StatusCode = System.Net.HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.JsonObject.ToString())
             });
-            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, 
-                httpClient: mockHttpClient.Object, 
+            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey,
+                httpClient: mockHttpClient.Object,
                 enableClientSideEvaluation: true,
                 cacheConfig: new CacheConfig(true));
 
             // When
             var flags = flagsmithClient.GetEnvironmentFlags().Result;
-            
+
             // Then
             Assert.NotNull(flags);
         }

--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -233,7 +233,7 @@ namespace Flagsmith.FlagsmithClientTest
         }
 
         [Fact]
-        public void testGetIdentitySegmentsNoTraits()
+        public void TestGetIdentitySegmentsNoTraits()
         {
             // Given
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
@@ -251,7 +251,7 @@ namespace Flagsmith.FlagsmithClientTest
         }
 
         [Fact]
-        public void testGetIdentitySegmentsWithValidTrait()
+        public void TestGetIdentitySegmentsWithValidTrait()
         {
             // Given
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
@@ -270,6 +270,27 @@ namespace Flagsmith.FlagsmithClientTest
             // Then
             Assert.Single(segments);
             Assert.Equal("Test segment", segments[0].Name);
+        }
+
+        [Fact]
+        public void TestFlagsmithClientWithCacheInitialization()
+        {
+            // Given
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.JsonObject.ToString())
+            });
+            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, 
+                httpClient: mockHttpClient.Object, 
+                enableClientSideEvaluation: true,
+                cacheConfig: new CacheConfig(true));
+
+            // When
+            var flags = flagsmithClient.GetEnvironmentFlags().Result;
+            
+            // Then
+            Assert.NotNull(flags);
         }
     }
 }

--- a/Flagsmith.FlagsmithClient/Cache/FlagListCache.cs
+++ b/Flagsmith.FlagsmithClient/Cache/FlagListCache.cs
@@ -14,9 +14,9 @@ namespace Flagsmith.Cache
         protected readonly IDateTimeProvider _dateTimeProvider;
         protected DateTime? _timestamp;
 
-        protected FlagListCache(IDateTimeProvider dateTimeProvider, IFlags flags, int cacheDurationInMinutes)
+        protected FlagListCache(IDateTimeProvider dateTimeProvider, int cacheDurationInMinutes)
         {
-            _flags = flags;
+            _flags = null;
             _dateTimeProvider = dateTimeProvider;
             _timestamp = null;
             _cacheDurationInMinutes = cacheDurationInMinutes;
@@ -24,12 +24,9 @@ namespace Flagsmith.Cache
 
         protected bool IsCacheStale()
         {
-            if (_timestamp == null)
-            {
-                return true;
-            }
-
-            return _dateTimeProvider.Now().Subtract((DateTime)_timestamp).TotalMinutes > _cacheDurationInMinutes;
+            return _timestamp == null ||
+                   _flags == null ||
+                   _dateTimeProvider.Now().Subtract((DateTime)_timestamp).TotalMinutes > _cacheDurationInMinutes;
         }
     }
 }

--- a/Flagsmith.FlagsmithClient/Cache/FlagListCache.cs
+++ b/Flagsmith.FlagsmithClient/Cache/FlagListCache.cs
@@ -18,7 +18,10 @@ namespace Flagsmith.Cache
         {
             _flags = flags;
             _dateTimeProvider = dateTimeProvider;
-            _timestamp = dateTimeProvider.Now();
+
+            //This is to ensure that the cache is stale on first run
+            _timestamp = dateTimeProvider.Now().Subtract(new TimeSpan(0, 0, cacheDurationInMinutes + 1, 0));
+
             _cacheDurationInMinutes = cacheDurationInMinutes;
         }
 

--- a/Flagsmith.FlagsmithClient/Cache/FlagListCache.cs
+++ b/Flagsmith.FlagsmithClient/Cache/FlagListCache.cs
@@ -12,22 +12,24 @@ namespace Flagsmith.Cache
 
         protected IFlags _flags;
         protected readonly IDateTimeProvider _dateTimeProvider;
-        protected DateTime _timestamp;
+        protected DateTime? _timestamp;
 
         protected FlagListCache(IDateTimeProvider dateTimeProvider, IFlags flags, int cacheDurationInMinutes)
         {
             _flags = flags;
             _dateTimeProvider = dateTimeProvider;
-
-            //This is to ensure that the cache is stale on first run
-            _timestamp = dateTimeProvider.Now().Subtract(new TimeSpan(0, 0, cacheDurationInMinutes + 1, 0));
-
+            _timestamp = null;
             _cacheDurationInMinutes = cacheDurationInMinutes;
         }
 
         protected bool IsCacheStale()
         {
-            return _dateTimeProvider.Now().Subtract(_timestamp).TotalMinutes > _cacheDurationInMinutes;
+            if (_timestamp == null)
+            {
+                return true;
+            }
+
+            return _dateTimeProvider.Now().Subtract((DateTime)_timestamp).TotalMinutes > _cacheDurationInMinutes;
         }
     }
 }

--- a/Flagsmith.FlagsmithClient/Cache/IdentityFlagListCache.cs
+++ b/Flagsmith.FlagsmithClient/Cache/IdentityFlagListCache.cs
@@ -1,4 +1,6 @@
-﻿using Flagsmith.Providers;
+﻿using System;
+using System.Collections.Generic;
+using Flagsmith.Providers;
 
 namespace Flagsmith.Cache
 {
@@ -6,8 +8,14 @@ namespace Flagsmith.Cache
     {
         private readonly IdentityWrapper _identityWrapper;
 
-        public IdentityFlagListCache(IdentityWrapper identityWrapper, IFlags flags, IDateTimeProvider dateTimeProvider, int cacheDurationInMinutes) :
-            base(dateTimeProvider, flags, cacheDurationInMinutes)
+        public IdentityFlagListCache(IdentityWrapper identityWrapper,
+            IDateTimeProvider dateTimeProvider,
+            AnalyticsProcessor analyticsProcessor,
+            Func<string, IFlag> defaultFlagHandler,
+            int cacheDurationInMinutes) :
+            base(dateTimeProvider,
+                new Flags(new List<IFlag>(), analyticsProcessor, defaultFlagHandler),
+                cacheDurationInMinutes)
         {
             _identityWrapper = identityWrapper;
         }

--- a/Flagsmith.FlagsmithClient/Cache/IdentityFlagListCache.cs
+++ b/Flagsmith.FlagsmithClient/Cache/IdentityFlagListCache.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Flagsmith.Providers;
+﻿using Flagsmith.Providers;
 
 namespace Flagsmith.Cache
 {
@@ -10,11 +8,8 @@ namespace Flagsmith.Cache
 
         public IdentityFlagListCache(IdentityWrapper identityWrapper,
             IDateTimeProvider dateTimeProvider,
-            AnalyticsProcessor analyticsProcessor,
-            Func<string, IFlag> defaultFlagHandler,
             int cacheDurationInMinutes) :
             base(dateTimeProvider,
-                new Flags(new List<IFlag>(), analyticsProcessor, defaultFlagHandler),
                 cacheDurationInMinutes)
         {
             _identityWrapper = identityWrapper;

--- a/Flagsmith.FlagsmithClient/Cache/RegularFlagListCache.cs
+++ b/Flagsmith.FlagsmithClient/Cache/RegularFlagListCache.cs
@@ -1,18 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using Flagsmith.Providers;
+﻿using Flagsmith.Providers;
 
 namespace Flagsmith.Cache
 {
     internal class RegularFlagListCache : FlagListCache
     {
         public RegularFlagListCache(IDateTimeProvider dateTimeProvider,
-            AnalyticsProcessor analyticsProcessor,
-            Func<string, IFlag> defaultFlagHandler,
             int cacheDurationInMinutes) :
-            base(dateTimeProvider,
-                new Flags(new List<IFlag>(), analyticsProcessor, defaultFlagHandler),
-                cacheDurationInMinutes)
+            base(dateTimeProvider, cacheDurationInMinutes)
         {
         }
 

--- a/Flagsmith.FlagsmithClient/Cache/RegularFlagListCache.cs
+++ b/Flagsmith.FlagsmithClient/Cache/RegularFlagListCache.cs
@@ -1,11 +1,18 @@
-﻿using Flagsmith.Providers;
+﻿using System;
+using System.Collections.Generic;
+using Flagsmith.Providers;
 
 namespace Flagsmith.Cache
 {
     internal class RegularFlagListCache : FlagListCache
     {
-        public RegularFlagListCache(IDateTimeProvider dateTimeProvider, IFlags flags, int cacheDurationInMinutes) :
-            base(dateTimeProvider, flags, cacheDurationInMinutes)
+        public RegularFlagListCache(IDateTimeProvider dateTimeProvider,
+            AnalyticsProcessor analyticsProcessor,
+            Func<string, IFlag> defaultFlagHandler,
+            int cacheDurationInMinutes) :
+            base(dateTimeProvider,
+                new Flags(new List<IFlag>(), analyticsProcessor, defaultFlagHandler),
+                cacheDurationInMinutes)
         {
         }
 

--- a/Flagsmith.FlagsmithClient/Flags.cs
+++ b/Flagsmith.FlagsmithClient/Flags.cs
@@ -1,9 +1,7 @@
 ﻿using FlagsmithEngine.Feature.Models;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Flagsmith

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -96,17 +96,20 @@ namespace Flagsmith
             this._httpClient = httpClient ?? new HttpClient();
             this.CacheConfig = cacheConfig ?? new CacheConfig(false);
             _engine = new Engine();
+
             if (EnableAnalytics)
                 _analyticsProcessor = new AnalyticsProcessor(this._httpClient, EnvironmentKey, ApiUrl, Logger, CustomHeaders);
+
             if (EnableClientSideEvaluation)
             {
                 _pollingManager = new PollingManager(GetAndUpdateEnvironmentFromApi, EnvironmentRefreshIntervalSeconds);
                 _ = _pollingManager.StartPoll();
             }
+
             if (CacheConfig.Enabled)
             {
                 _regularFlagListCache = new RegularFlagListCache(new DateTimeProvider(),
-                    GetEnvironmentFlags().Result,
+                    new Flags(new List<IFlag>(), _analyticsProcessor, DefaultFlagHandler),
                     CacheConfig.DurationInMinutes);
                 _flagListCacheDictionary = new Dictionary<string, IdentityFlagListCache>();
             }
@@ -142,6 +145,7 @@ namespace Flagsmith
             {
                 return _regularFlagListCache.GetLatestFlags(GetFeatureFlagsFromCorrectSource);
             }
+
             return await GetFeatureFlagsFromCorrectSource();
         }
 

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -109,8 +109,6 @@ namespace Flagsmith
             if (CacheConfig.Enabled)
             {
                 _regularFlagListCache = new RegularFlagListCache(new DateTimeProvider(),
-                    _analyticsProcessor,
-                    DefaultFlagHandler,
                     CacheConfig.DurationInMinutes);
                 _flagListCacheDictionary = new Dictionary<string, IdentityFlagListCache>();
             }
@@ -216,8 +214,6 @@ namespace Flagsmith
             {
                 flagListCache = new IdentityFlagListCache(identityWrapper,
                     new DateTimeProvider(),
-                    _analyticsProcessor,
-                    DefaultFlagHandler,
                     CacheConfig.DurationInMinutes);
                 _flagListCacheDictionary.Add(identityWrapper.CacheKey, flagListCache);
             }

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -109,7 +109,8 @@ namespace Flagsmith
             if (CacheConfig.Enabled)
             {
                 _regularFlagListCache = new RegularFlagListCache(new DateTimeProvider(),
-                    new Flags(new List<IFlag>(), _analyticsProcessor, DefaultFlagHandler),
+                    _analyticsProcessor,
+                    DefaultFlagHandler,
                     CacheConfig.DurationInMinutes);
                 _flagListCacheDictionary = new Dictionary<string, IdentityFlagListCache>();
             }
@@ -214,8 +215,9 @@ namespace Flagsmith
             if (flagListCache == null)
             {
                 flagListCache = new IdentityFlagListCache(identityWrapper,
-                    GetIdentityFlags(identityWrapper.Identifier, identityWrapper.Traits).Result,
                     new DateTimeProvider(),
+                    _analyticsProcessor,
+                    DefaultFlagHandler,
                     CacheConfig.DurationInMinutes);
                 _flagListCacheDictionary.Add(identityWrapper.CacheKey, flagListCache);
             }


### PR DESCRIPTION
There was no need to initiate the cache right at the beginning. 
In fact, it was creating a problem trying to call `GetLatestFlags` on the cache that was currently trying to be initialized for the first time.
