### PR TITLE
fix: Ensure environment is retrieved on start polling

### DIFF
--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -242,7 +242,7 @@ namespace Flagsmith
                     }
 
                     var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(RequestTimeout ?? 100));
-                    HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationTokenSource.Token);
+                    HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationTokenSource.Token).ConfigureAwait(false);
                     return response.EnsureSuccessStatusCode();
                 })).Content.ReadAsStringAsync();
             }

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -103,7 +103,7 @@ namespace Flagsmith
             if (EnableClientSideEvaluation)
             {
                 _pollingManager = new PollingManager(GetAndUpdateEnvironmentFromApi, EnvironmentRefreshIntervalSeconds);
-                _ = _pollingManager.StartPoll();
+                _pollingManager.StartPoll().GetAwaiter().GetResult();
             }
 
             if (CacheConfig.Enabled)


### PR DESCRIPTION
Ensures environment is retrieved on start polling by executing the StartPoll() method synchronoulsy, and executing the first call to the callback `GetAndUpdateEnvironmentFromApi` also asynchronoulsy and immediately. While(true) and Delay funcitons replaced by Timer class to allow the StartPoll() to be executed synchronously without hanging the execution of the main thread.
