### PR TITLE
feat: Identity overrides in local evaluation mode

### DIFF
--- a/Flagsmith.Client.Test/Fixtures.cs
+++ b/Flagsmith.Client.Test/Fixtures.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
@@ -65,6 +65,31 @@ namespace Flagsmith.FlagsmithClientTest
       },
       'segment_id': null,
       'enabled': true
+    }
+  ],
+  'identity_overrides': [
+    {
+      'identifier': 'overridden-id',
+      'identity_uuid': '0f21cde8-63c5-4e50-baca-87897fa6cd01',
+      'created_date': '2019-08-27T14:53:45.698555Z',
+      'updated_at': '2023-07-14T16:12:00.000000',
+      'environment_api_key': 'test_key',
+      'identity_features': [
+        {
+          'id': 1,
+          'feature': {
+            'id': 1,
+            'name': 'some_feature',
+            'type': 'STANDARD'
+          },
+          'featurestate_uuid': '1bddb9a5-7e59-42c6-9be9-625fa369749f',
+          'feature_state_value': 'some-overridden-value',
+          'enabled': false,
+          'environment': 1,
+          'identity': null,
+          'feature_segment': null
+        }
+      ]
     }
   ]
 }");

--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -126,6 +126,25 @@ namespace Flagsmith.FlagsmithClientTest
             mockHttpClient.verifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
         }
         [Fact]
+        public async Task TestGetIdentityFlagsUsesLocalIdentityOverridesWhenAvailable()
+        {
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.JsonObject.ToString())
+            });
+
+            var traits = new List<ITrait> { new Trait("foo", "bar") };
+
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, enableClientSideEvaluation: true, httpClient: mockHttpClient.Object);
+            mockHttpClient.verifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
+
+            var flags = await flagsmithClientTest.GetIdentityFlags("overridden-id", traits);
+            var flag = await flags.GetFlag("some_feature");
+            Assert.False(flag.Enabled);
+            Assert.Equal("some-overridden-value", flag.Value);
+        }
+        [Fact]
         public async Task TestRequestConnectionErrorRaisesFlagsmithApiError()
         {
             var mockHttpClient = HttpMocker.MockHttpThrowConnectionError();

--- a/Flagsmith.Engine/Environment/Models/EnvironmentModel.cs
+++ b/Flagsmith.Engine/Environment/Models/EnvironmentModel.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using FlagsmithEngine.Project.Models;
 using FlagsmithEngine.Feature.Models;
+using FlagsmithEngine.Identity.Models;
 
 namespace FlagsmithEngine.Environment.Models
 {
@@ -17,10 +18,7 @@ namespace FlagsmithEngine.Environment.Models
         public ProjectModel Project { get; set; }
         [JsonProperty(PropertyName = "feature_states")]
         public List<FeatureStateModel> FeatureStates { get; set; }
-        public IntegrationModel AmplitudeConfig { get; set; }
-        public IntegrationModel SegmentConfig { get; set; }
-        public IntegrationModel MixpanelConfig { get; set; }
-        public IntegrationModel HeapConfig { get; set; }
-
+        [JsonProperty(PropertyName = "identity_overrides")]
+        public List<IdentityModel> IdentityOverrides { get; set; }
     }
 }

--- a/Flagsmith.Engine/Identity/Models/IdentityModel.cs
+++ b/Flagsmith.Engine/Identity/Models/IdentityModel.cs
@@ -29,7 +29,7 @@ namespace FlagsmithEngine.Identity.Models
         public string GenerateCompositeKey(string envKey, string identifier) => $"{envKey}_{identifier}";
         public void UpdateTraits(List<TraitModel> traits)
         {
-            var existingModels = IdentityTraits.ToDictionary(x => x.TraitKey);
+            var existingModels = IdentityTraits?.Count > 0 ? IdentityTraits.ToDictionary(x => x.TraitKey) : new Dictionary<string, TraitModel>();
             traits.ForEach(trait =>
             {
                 if (trait.TraitValue is null)


### PR DESCRIPTION
Contributes to https://github.com/Flagsmith/flagsmith/issues/3132.
Closes https://github.com/Flagsmith/flagsmith-dotnet-client/issues/89.

- Add support for environment-provided identities
- Remove unneeded integration configuration models
- Fix `IdentityModel.UpdateTraits` to support null traits