### PR TITLE
chore: Implement multi-threading support for analytics Processor

### DIFF
--- a/Flagsmith.Client.Test/AnalyticsProcessorTest.cs
+++ b/Flagsmith.Client.Test/AnalyticsProcessorTest.cs
@@ -22,12 +22,12 @@ namespace Flagsmith.FlagsmithClientTest
         /// </summary>
         /// <param name="featureId"></param>
         /// <returns></returns>
-        public int this[string featureName] => AnalyticsData[featureName];
+        public int this[string featureName] => GetAggregatedAnalytics()[featureName];
         /// <summary>
         /// Check if there are any items in analytics cache.
         /// </summary>
         /// <returns></returns>
-        public bool HasTrackingItemsInCache() => AnalyticsData.Any();
-        public override string ToString() => JsonConvert.SerializeObject(AnalyticsData);
+        public bool HasTrackingItemsInCache() => GetAggregatedAnalytics().Any();
+        public override string ToString() => JsonConvert.SerializeObject(GetAggregatedAnalytics());
     }
 }

--- a/Flagsmith.Client.Test/AnalyticsTests.cs
+++ b/Flagsmith.Client.Test/AnalyticsTests.cs
@@ -102,59 +102,5 @@ namespace Flagsmith.FlagsmithClientTest
             // Then
             Assert.True(true);
         }
-
-        [Fact]
-        public async Task TestAnalyticsProcessorDataConcurrentConsistency()
-        {
-            // Given
-            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
-            {
-                StatusCode = System.Net.HttpStatusCode.OK,
-            });
-
-            Dictionary<string, int> featuresDictionary = new Dictionary<string, int>();
-            for (int i = 1; i <= 10; i++)
-            {
-                featuresDictionary.TryAdd($"Feature_{i}", 0);
-            }
-
-            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, baseApiUrl: _defaultApiUrl);
-            const int numberOfThreads = 1000;
-            const int callsPerThread = 1000;
-
-            // When 
-            var tasks = new Task[numberOfThreads];
-            for (int i = 0; i < tasks.Length; i++)
-            {
-                var local = i;
-                string[] features = new string[callsPerThread];
-                for (int j = 0; j < callsPerThread; j++)
-                {
-                    string feature = $"Feature_{new Random().Next(1, featuresDictionary.Count + 1)}";
-                    features[j] = feature;
-                    featuresDictionary[feature]++;
-                }
-
-                tasks[i] = Task.Run(async () =>
-                {
-                    foreach (var feature in features)
-                    {
-                        await analyticsProcessor.TrackFeature(feature);
-                    }
-                });
-            }
-
-            await Task.WhenAll(tasks);
-
-            // Then
-            Dictionary<string, int> analyticsData = analyticsProcessor.GetAggregatedAnalytics();
-            int totalCallsMade = 0;
-            foreach (var feature in featuresDictionary)
-            {
-                totalCallsMade += analyticsData[feature.Key];
-                Assert.Equal(feature.Value, analyticsData[feature.Key]);
-            }
-            Assert.Equal(numberOfThreads * callsPerThread, totalCallsMade);
-        }
     }
 }

--- a/Flagsmith.Client.Test/AnalyticsTests.cs
+++ b/Flagsmith.Client.Test/AnalyticsTests.cs
@@ -116,7 +116,7 @@ namespace Flagsmith.FlagsmithClientTest
             for (int i = 1; i <= 10; i++)
             {
                 featuresDictionary.TryAdd($"Feature_{i}", 0);
-            }    
+            }
 
             var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, baseApiUrl: _defaultApiUrl);
             const int numberOfThreads = 1000;
@@ -134,7 +134,7 @@ namespace Flagsmith.FlagsmithClientTest
                     features[j] = feature;
                     featuresDictionary[feature]++;
                 }
-                
+
                 tasks[i] = Task.Run(async () =>
                 {
                     foreach (var feature in features)
@@ -154,6 +154,7 @@ namespace Flagsmith.FlagsmithClientTest
                 totalCallsMade += analyticsData[feature.Key];
                 Assert.Equal(feature.Value, analyticsData[feature.Key]);
             }
-            Assert.Equal(numberOfThreads * callsPerThread, totalCallsMade);        }
+            Assert.Equal(numberOfThreads * callsPerThread, totalCallsMade);
+        }
     }
 }

--- a/Flagsmith.Client.Test/Fixtures.cs
+++ b/Flagsmith.Client.Test/Fixtures.cs
@@ -153,10 +153,10 @@ namespace Flagsmith.FlagsmithClientTest
                 {
                     object flag = new
                     {
-                        id = 1,
+                        id = i,
                         feature = new
                         {
-                            id = 1,
+                            id = i,
                             name = $"Feature_{i}",
                             created_date = "2019-08-27T14 =53 =45.698555Z",
                             default_enabled = false,

--- a/Flagsmith.Client.Test/Fixtures.cs
+++ b/Flagsmith.Client.Test/Fixtures.cs
@@ -1,8 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Text;
 using FlagsmithEngine.Environment.Models;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Flagsmith.FlagsmithClientTest
@@ -144,5 +143,35 @@ namespace Flagsmith.FlagsmithClientTest
     ]
 }";
 
+        public static string ApiFlagResponseWithTenFlags
+        {
+          get
+          {
+            List<object> flags = new List<object>();
+            // Add ten flags named Feature_1, Feature_2, ..., Feature_10
+            for (int i = 1; i <= 10; i++)
+            {
+              object flag = new
+              {
+                id = 1,
+                feature = new {
+                    id = 1,
+                    name = $"Feature_{i}",
+                    created_date = "2019-08-27T14 =53 =45.698555Z",
+                    default_enabled = false,
+                    type = "STANDARD",
+                    project = 1
+                },
+                feature_state_value = "some-value",
+                enabled = true,
+                environment = 1,
+              };
+              flags.Add(flag);
+            };
+            var json = JsonConvert.SerializeObject(flags);
+            // Return the JSON string representation of the flags list
+            return json;
+          }
+        }
     }
 }

--- a/Flagsmith.Client.Test/Fixtures.cs
+++ b/Flagsmith.Client.Test/Fixtures.cs
@@ -145,33 +145,34 @@ namespace Flagsmith.FlagsmithClientTest
 
         public static string ApiFlagResponseWithTenFlags
         {
-          get
-          {
-            List<object> flags = new List<object>();
-            // Add ten flags named Feature_1, Feature_2, ..., Feature_10
-            for (int i = 1; i <= 10; i++)
+            get
             {
-              object flag = new
-              {
-                id = 1,
-                feature = new {
-                    id = 1,
-                    name = $"Feature_{i}",
-                    created_date = "2019-08-27T14 =53 =45.698555Z",
-                    default_enabled = false,
-                    type = "STANDARD",
-                    project = 1
-                },
-                feature_state_value = "some-value",
-                enabled = true,
-                environment = 1,
-              };
-              flags.Add(flag);
-            };
-            var json = JsonConvert.SerializeObject(flags);
-            // Return the JSON string representation of the flags list
-            return json;
-          }
+                List<object> flags = new List<object>();
+                // Add ten flags named Feature_1, Feature_2, ..., Feature_10
+                for (int i = 1; i <= 10; i++)
+                {
+                    object flag = new
+                    {
+                        id = 1,
+                        feature = new
+                        {
+                            id = 1,
+                            name = $"Feature_{i}",
+                            created_date = "2019-08-27T14 =53 =45.698555Z",
+                            default_enabled = false,
+                            type = "STANDARD",
+                            project = 1
+                        },
+                        feature_state_value = "some-value",
+                        enabled = true,
+                        environment = 1,
+                    };
+                    flags.Add(flag);
+                };
+                var json = JsonConvert.SerializeObject(flags);
+                // Return the JSON string representation of the flags list
+                return json;
+            }
         }
     }
 }

--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -431,5 +431,62 @@ namespace Flagsmith.FlagsmithClientTest
             var exception = Assert.Throws<Exception>(() => createFlagsmith());
             Assert.Equal("ValueError: environmentKey is required", exception.Message);
         }
+
+        [Fact]
+        public async Task TestAnalyticsDataConsistencyWithConcurrentCallsToGetFlags()
+        {
+            // Given
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiFlagResponseWithTenFlags)
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, enableAnalytics: true);
+            var flags = await flagsmithClientTest.GetEnvironmentFlags();
+
+            Dictionary<string, int> featuresDictionary = new Dictionary<string, int>();
+
+            for (int i = 1; i <= 10; i++)
+            {
+                featuresDictionary.TryAdd($"Feature_{i}", 0);
+            }
+
+            const int numberOfThreads = 1000;
+            const int callsPerThread = 1000;
+
+            // When 
+            var tasks = new Task[numberOfThreads];
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                var local = i;
+                string[] features = new string[callsPerThread];
+                for (int j = 0; j < callsPerThread; j++)
+                {
+                    string feature = $"Feature_{new Random().Next(1, featuresDictionary.Count + 1)}";
+                    features[j] = feature;
+                    featuresDictionary[feature]++;
+                }
+
+                tasks[i] = Task.Run(async () =>
+                {
+                    foreach (var feature in features)
+                    {
+                        await flags.IsFeatureEnabled(feature);
+                    }
+                });
+            }
+
+            await Task.WhenAll(tasks);
+
+            // Then
+            Dictionary<string, int> analyticsData = flagsmithClientTest.aggregatedAnalytics;
+            int totalCallsMade = 0;
+            foreach (var feature in featuresDictionary)
+            {
+                totalCallsMade += analyticsData[feature.Key];
+                Assert.Equal(feature.Value, analyticsData[feature.Key]);
+            }
+            Assert.Equal(numberOfThreads * callsPerThread, totalCallsMade);
+        }
     }
 }

--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -474,12 +474,11 @@ namespace Flagsmith.FlagsmithClientTest
                 // Prepare an array of feature names of length callsPerThread.
                 for (int j = 0; j < callsPerThread; j++)
                 {
-                    ```suggestion
                     // The feature names are randomly selected from the featuresDictionary and added to the 
                     // list of features, which represents the features that have been evaluated.  
                     string featureName = $"Feature_{new Random().Next(1, featuresDictionary.Count + 1)}";
                     features[j] = featureName;
-                    
+
                     // The relevant key in the featuresDictionary is incremented to simulate an evaluation
                     // to track for that feature. 
                     featuresDictionary[featureName]++;

--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -474,9 +474,14 @@ namespace Flagsmith.FlagsmithClientTest
                 // Prepare an array of feature names of length callsPerThread.
                 for (int j = 0; j < callsPerThread; j++)
                 {
-                    // The feature names are randomly picked from the featuresDictionary which contains numberOfFeatures feature names.
+                    ```suggestion
+                    // The feature names are randomly selected from the featuresDictionary and added to the 
+                    // list of features, which represents the features that have been evaluated.  
                     string featureName = $"Feature_{new Random().Next(1, featuresDictionary.Count + 1)}";
                     features[j] = featureName;
+                    
+                    // The relevant key in the featuresDictionary is incremented to simulate an evaluation
+                    // to track for that feature. 
                     featuresDictionary[featureName]++;
                 }
 

--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -464,17 +464,23 @@ namespace Flagsmith.FlagsmithClientTest
 
             // When 
             var tasks = new Task[numberOfThreads];
-            for (int i = 0; i < tasks.Length; i++)
+
+            // Create numberOfThreads threads.
+            for (int i = 0; i < numberOfThreads; i++)
             {
                 var local = i;
                 string[] features = new string[callsPerThread];
+
+                // Prepare an array of feature names of length callsPerThread.
                 for (int j = 0; j < callsPerThread; j++)
                 {
+                    // The feature names are randomly picked from the featuresDictionary which contains numberOfFeatures feature names.
                     string featureName = $"Feature_{new Random().Next(1, featuresDictionary.Count + 1)}";
                     features[j] = featureName;
                     featuresDictionary[featureName]++;
                 }
 
+                // Each thread will call IsFeatureEnabled for callsPerThread times.
                 tasks[i] = Task.Run(async () =>
                 {
                     foreach (var feature in features)

--- a/Flagsmith.FlagsmithClient/AnalyticsProcessor.cs
+++ b/Flagsmith.FlagsmithClient/AnalyticsProcessor.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Flagsmith.Extensions;
+using System.Collections.Concurrent;
 
 namespace Flagsmith
 {
@@ -18,7 +19,7 @@ namespace Flagsmith
         readonly string _EnvironmentKey;
         readonly int _TimeOut;
         DateTime _LastFlushed;
-        protected Dictionary<string, int> AnalyticsData;
+        protected ConcurrentDictionary <string, int> AnalyticsData;
         HttpClient _HttpClient;
         ILogger _Logger;
         Dictionary<string, string> _CustomHeaders;
@@ -28,7 +29,7 @@ namespace Flagsmith
             _AnalyticsEndPoint = baseApiUrl + "analytics/flags/";
             _TimeOut = timeOut;
             _LastFlushed = DateTime.Now;
-            AnalyticsData = new Dictionary<string, int>();
+            AnalyticsData = new ConcurrentDictionary <string, int>();
             _HttpClient = httpClient;
             _Logger = logger;
             _FlushIntervalSeconds = flushIntervalSeconds;

--- a/Flagsmith.FlagsmithClient/AnalyticsProcessor.cs
+++ b/Flagsmith.FlagsmithClient/AnalyticsProcessor.cs
@@ -41,12 +41,12 @@ namespace Flagsmith
 
         public static AnalyticsProcessor GetInstance(HttpClient httpClient, string environmentKey, string baseApiUrl, ILogger logger = null, Dictionary<string, string> customHeaders = null, int timeOut = 3, int flushIntervalSeconds = 10)
         {
-            if(_Instance == null)
-                {
+            if (_Instance == null)
+            {
                 _Instance = new AnalyticsProcessor(httpClient, environmentKey, baseApiUrl, logger, customHeaders, timeOut, flushIntervalSeconds);
-                }
+            }
 
-                return _Instance;
+            return _Instance;
         }
 
         /// <summary>

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -408,7 +408,7 @@ namespace Flagsmith
             return Flags.FromFeatureStateModel(_analyticsProcessor, DefaultFlagHandler, _engine.GetIdentityFeatureStates(Environment, identity), identity.CompositeKey);
         }
 
-        public Dictionary<string, int> aggregatedAnalytics => _analyticsProcessor != null ? _analyticsProcessor.GetAggregatedAnalytics(): new Dictionary<string, int>();
+        public Dictionary<string, int> aggregatedAnalytics => _analyticsProcessor != null ? _analyticsProcessor.GetAggregatedAnalytics() : new Dictionary<string, int>();
 
         ~FlagsmithClient() => _pollingManager?.StopPoll();
     }

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -408,6 +408,8 @@ namespace Flagsmith
             return Flags.FromFeatureStateModel(_analyticsProcessor, DefaultFlagHandler, _engine.GetIdentityFeatureStates(Environment, identity), identity.CompositeKey);
         }
 
+        public Dictionary<string, int> aggregatedAnalytics => _analyticsProcessor != null ? _analyticsProcessor.GetAggregatedAnalytics(): new Dictionary<string, int>();
+
         ~FlagsmithClient() => _pollingManager?.StopPoll();
     }
 }

--- a/Flagsmith.FlagsmithClient/IAnalyticsProcessor.cs
+++ b/Flagsmith.FlagsmithClient/IAnalyticsProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Flagsmith
 {
@@ -16,5 +17,11 @@ namespace Flagsmith
         /// <param name="featureId"></param>
         /// <returns></returns>
         Task TrackFeature(string featureName);
+
+        /// <summary>
+        /// Get aggregated analytics data.
+        /// </summary>
+        /// <returns>Dictionary of feature name and usage count</returns>
+        public Dictionary<string, int> GetAggregatedAnalytics();
     }
 }


### PR DESCRIPTION
Implement support for multi-threading processing in the AnalyticsProcessor class.

Also, implements unit tests replicating potential issues. The issues show themselves only with a huge number of threads running concurrently, and at a certain number it is possible to reproduce them systematically, while that number could depend on the machine resources this has been tested on a MAC Book Pro M2 Processor with 16GB and on a PC with Corei7 and 48GB of RAM.

Please refer to this issue https://github.com/Flagsmith/flagsmith-dotnet-client/issues/88 for more context.