### PR TITLE
fix: Providing an OfflineHandler causes the SDK to bypass live flag lookups

### DIFF
--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -203,7 +203,7 @@ namespace Flagsmith
 
         private async Task<IFlags> GetFeatureFlagsFromCorrectSource()
         {
-            return Environment != null ? GetFeatureFlagsFromDocument() : await GetFeatureFlagsFromApi().ConfigureAwait(false);
+            return OfflineMode ? GetFeatureFlagsFromDocument() : await GetFeatureFlagsFromApi().ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #103 