### PR TITLE
fix: OfflineHandler causes the SDK to bypass live flag lookups

### DIFF
--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -53,7 +53,7 @@ namespace Flagsmith.FlagsmithClientTest
             mockHttpClient.verifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
             await flagsmithClientTest.GetEnvironmentFlags();
             mockHttpClient.verifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
-            mockHttpClient.verifyHttpRequest(HttpMethod.Get, "/api/v1/flags/", Times.Once);
+            mockHttpClient.verifyHttpRequest(HttpMethod.Get, "/api/v1/flags/", Times.Never);
         }
         [Fact]
         public async Task TestGetEnvironmentFlagsCallsApiWhenNoLocalEnvironment()
@@ -78,13 +78,13 @@ namespace Flagsmith.FlagsmithClientTest
             {
                 { "/api/v1/environment-document/", new HttpResponseMessage
                     {
-                        StatusCode = System.Net.HttpStatusCode.OK,
+                        StatusCode = HttpStatusCode.OK,
                         Content = new StringContent(Fixtures.JsonObject.ToString())
                     }
                 },
                 { "/api/v1/flags/", new HttpResponseMessage
                     {
-                        StatusCode = System.Net.HttpStatusCode.OK,
+                        StatusCode = HttpStatusCode.OK,
                         Content = new StringContent(Fixtures.ApiFlagResponse)
                     }
                 }

--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -455,7 +455,9 @@ namespace Flagsmith.FlagsmithClientTest
 
             // Then
             var environmentFlags = await flagsmithClientTest.GetEnvironmentFlags();
+            mockHttpClient.verifyHttpRequest(HttpMethod.Get, "/api/v1/flags/", Times.Once);
             Assert.True(await environmentFlags.IsFeatureEnabled("some_feature"));
+            Assert.NotEqual("offline-value", await environmentFlags.GetFeatureValue("some_feature"));
             Assert.Equal("some-value", await environmentFlags.GetFeatureValue("some_feature"));
         }
 

--- a/Flagsmith.Client.Test/HttpMocker.cs
+++ b/Flagsmith.Client.Test/HttpMocker.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using System.Net;
 
 namespace Flagsmith.FlagsmithClientTest
 {
@@ -52,6 +53,26 @@ namespace Flagsmith.FlagsmithClientTest
           req.Method == httpMethod &&
           req.RequestUri.AbsolutePath == url &&
           (queryString == "" || req.RequestUri.Query.Equals($"?{queryString}"))), It.IsAny<CancellationToken>()), times);
+        }
+
+        public static Mock<HttpClient> MockHttpResponse(Dictionary<string, HttpResponseMessage> responses)
+        {
+            var httpClientMock = new Mock<HttpClient>();
+
+            httpClientMock.Setup(x => x.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .Returns((HttpRequestMessage request, CancellationToken token) =>
+                {
+                    var url = request.RequestUri.PathAndQuery;
+
+                    if (responses.TryGetValue(url, out var response))
+                    {
+                        return Task.FromResult(response);
+                    }
+
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+                });
+
+            return httpClientMock;
         }
     }
 }

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -203,7 +203,7 @@ namespace Flagsmith
 
         private async Task<IFlags> GetFeatureFlagsFromCorrectSource()
         {
-            return OfflineMode && Environment != null ? GetFeatureFlagsFromDocument() : await GetFeatureFlagsFromApi().ConfigureAwait(false);
+            return (OfflineMode || EnableClientSideEvaluation) && Environment != null ? GetFeatureFlagsFromDocument() : await GetFeatureFlagsFromApi().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -236,7 +236,7 @@ namespace Flagsmith
 
         public async Task<IFlags> GetIdentityFlagsFromCorrectSource(IdentityWrapper identityWrapper)
         {
-            if (Environment != null)
+            if ((OfflineMode || EnableClientSideEvaluation) && Environment != null)
             {
                 return GetIdentityFlagsFromDocument(identityWrapper.Identifier, identityWrapper.Traits);
             }

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -203,7 +203,7 @@ namespace Flagsmith
 
         private async Task<IFlags> GetFeatureFlagsFromCorrectSource()
         {
-            return Environment != null ? GetFeatureFlagsFromDocument() : await GetFeatureFlagsFromApi().ConfigureAwait(false);
+            return OfflineMode && Environment != null ? GetFeatureFlagsFromDocument() : await GetFeatureFlagsFromApi().ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixing https://github.com/Flagsmith/flagsmith-dotnet-client/issues/103

- An additional validation was added to avoid always using the offlineHandler document when it is set.

- Added a new test for this specific case