### PR TITLE
deps: bump artifact options

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     - run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }}
 
     # Publish the NuGet package as an artifact, so they can be used in the following jobs
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: nuget
         if-no-files-found: error
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-dotnet@v4
 
       # Download the NuGet package created in the previous job
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: nuget
           path: ${{ env.NuGetDirectory }}
@@ -70,7 +70,7 @@ jobs:
         - validate_nuget
     steps:
       # Download the NuGet package created in the previous job
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: nuget
           path: ${{ env.NuGetDirectory }}


### PR DESCRIPTION
Supersedes #114 which only updated download-artifact (which is stated as not being backwards compatible with artifacts uploaded with v3 [here](https://github.com/actions/download-artifact/releases/tag/v4.0.0)). 