### PR TITLE
Add ConfigureAwait(false) to AnalyticsProcessor

### DIFF
--- a/Flagsmith.FlagsmithClient/AnalyticsProcessor.cs
+++ b/Flagsmith.FlagsmithClient/AnalyticsProcessor.cs
@@ -71,7 +71,7 @@ namespace Flagsmith
                 _CustomHeaders?.ForEach(kvp => request.Headers.Add(kvp.Key, kvp.Value));
                 var tokenSource = new CancellationTokenSource();
                 tokenSource.CancelAfter(TimeSpan.FromSeconds(_TimeOut));
-                var response = await _HttpClient.SendAsync(request, tokenSource.Token);
+                var response = await _HttpClient.SendAsync(request, tokenSource.Token).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
                 _Logger?.LogInformation("Analytics posted: " + analyticsJson);
                 AnalyticsDataThreads.Clear();

--- a/Flagsmith.FlagsmithClient/AnalyticsProcessor.cs
+++ b/Flagsmith.FlagsmithClient/AnalyticsProcessor.cs
@@ -116,7 +116,7 @@ namespace Flagsmith
             int _LastFlushedInterval = (DateTime.Now - _LastFlushed).Seconds;
 
             if (_LastFlushedInterval > _FlushIntervalSeconds)
-                await Flush();
+                await Flush().ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
This adds ConfigureAwait(false) to AnalyticsProcessor.cs, per https://github.com/Flagsmith/flagsmith-dotnet-client/issues/113.