### PR TITLE
chore: bump version to 5.4.1

### DIFF
--- a/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj
+++ b/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PackageId>Flagsmith</PackageId>
     <Title>Flagsmith</Title>
-    <Version>5.3.2</Version>
+    <Version>5.4.1</Version>
     <Authors>flagsmith</Authors>
     <Company>Flagsmith</Company>
     <PackageDescription>Client SDK for Flagsmith. Ship features with confidence using feature flags and remote config. Host yourself or use our hosted version at https://flagsmith.com/</PackageDescription>


### PR DESCRIPTION
Forgot to bump version before releasing https://github.com/Flagsmith/flagsmith-dotnet-client/releases/tag/v5.4.1

This means 5.3.2 in nuget actually corresponds to the current 5.4.1 - we can fix this later, and releasing 5.4.1 again will now work as we expect.