### PR TITLE
Fix constructor deadlock when using local evaluation

### DIFF
--- a/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj
+++ b/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PackageId>Flagsmith</PackageId>
     <Title>Flagsmith</Title>
-    <Version>5.3.2</Version>
+    <Version>5.4.2</Version>
     <Authors>flagsmith</Authors>
     <Company>Flagsmith</Company>
     <PackageDescription>Client SDK for Flagsmith. Ship features with confidence using feature flags and remote config. Host yourself or use our hosted version at https://flagsmith.com/</PackageDescription>

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -155,7 +155,7 @@ namespace Flagsmith
                     }
 
                     _pollingManager = new PollingManager(GetAndUpdateEnvironmentFromApi, EnvironmentRefreshIntervalSeconds);
-                    _pollingManager.StartPoll().GetAwaiter().GetResult();
+                    Task.Run(async () => await _pollingManager.StartPoll()).GetAwaiter().GetResult();
                 }
             }
 


### PR DESCRIPTION
Fixes a deadlock when awaiting the initial poll for local evaluation mode in the `FlagsmithClient` constructor in ASP.NET MVC.

This can be reproduced with the following sample project, by setting a correct server-side environment key here: https://github.com/rolodato/flagsmith-dotnet-mvc-deadlock-repro/blob/18bc0633d1e5c5443c2d79bc2fde5eb10eb880d1/flagsmith-error-repro/Controllers/HomeController.cs#L14. To reproduce, run the solution in Visual Studio and the index page will hang forever. I was not able to reproduce this deadlock on macOS with Mono - it only happened on Windows.

This can be also worked around from the application side by instantiating `FlagsmithClient` in an asynchronous view, but this does not play well with IoC/DI solutions such as [Autofac](https://autofac.org/):

```csharp
public async Task<ActionResult> Index()
{
    var flagsmithClient = await Task.Run(() =>
    {
        return new FlagsmithClient("ser....", enableClientSideEvaluation: true);
    });
    // validates flags are actually being returned here
    System.Diagnostics.Debug.WriteLine((await flagsmithClient.GetEnvironmentFlags()).AllFlags()[0]);
    return View();
}
```

An alternative solution would be to provide an async factory method that can be `await`ed instead of relying on a synchronous constructor.

