### PR TITLE
fix: handle null django_id in identity overrides for local evaluation mode

### DIFF
--- a/Flagsmith.Client.Test/Fixtures.cs
+++ b/Flagsmith.Client.Test/Fixtures.cs
@@ -84,6 +84,7 @@ namespace Flagsmith.FlagsmithClientTest
           'featurestate_uuid': '1bddb9a5-7e59-42c6-9be9-625fa369749f',
           'feature_state_value': 'some-overridden-value',
           'enabled': false,
+          'django_id': null,
           'environment': 1,
           'identity': null,
           'feature_segment': null

--- a/Flagsmith.Engine/Feature/Models/FeatureStateModel.cs
+++ b/Flagsmith.Engine/Feature/Models/FeatureStateModel.cs
@@ -22,7 +22,7 @@ namespace FlagsmithEngine.Feature.Models
         [JsonProperty(PropertyName = "multivariate_feature_state_values")]
         public List<MultivariateFeatureStateValueModel> MultivariateFeatureStateValues { get; set; }
         [JsonProperty(PropertyName = "django_id")]
-        public int DjangoId { get; set; }
+        public int? DjangoId { get; set; }
         public string FeatureStateUUID { get; set; } = new Guid().ToString();
         [JsonProperty(PropertyName = "feature_segment")]
         public FeatureSegmentModel FeatureSegment { get; set; } = null;
@@ -33,7 +33,7 @@ namespace FlagsmithEngine.Feature.Models
         {
             var percentageValue = Hashing.GetHashedPercentageForObjectIds(new List<string>
             {
-              DjangoId != 0 ? DjangoId.ToString() : FeatureStateUUID,
+              DjangoId != null ? DjangoId.ToString() : FeatureStateUUID,
               identityId.ToString()
             });
             var startPercentage = 0.0;

--- a/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj
+++ b/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PackageId>Flagsmith</PackageId>
     <Title>Flagsmith</Title>
-    <Version>5.4.2</Version>
+    <Version>5.4.3</Version>
     <Authors>flagsmith</Authors>
     <Company>Flagsmith</Company>
     <PackageDescription>Client SDK for Flagsmith. Ship features with confidence using feature flags and remote config. Host yourself or use our hosted version at https://flagsmith.com/</PackageDescription>


### PR DESCRIPTION
I'm not sure how `django_id` can return null here, but other SDKs do handle this possibility:

* https://github.com/Flagsmith/flagsmith-ruby-client/blob/d467610cc9ad868082aeb6ce58322dbd3cf669dc/lib/flagsmith/engine/identities/models.rb#L17
* https://github.com/Flagsmith/flagsmith-php-client/blob/7c20db24691fe5a59cc69676733df93bb543255f/src/Engine/Identities/IdentityModel.php#L23
* https://github.com/Flagsmith/flagsmith-engine/blob/902aa899ce156012e6551fe9a8499848ccafdfbf/flag_engine/features/models.py#L78

This caused an exception in the `FlagsmithClient` constructor similar to this:

```
Newtonsoft.Json.JsonSerializationException

  HResult=0x80131500

  Message=Error converting value {null} to type 'System.Int32'. Path 'identity_overrides[0].identity_features[0].django_id', line 1, position 1372.

  Source=Newtonsoft.Json

  StackTrace:

   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)
```