### PR TITLE
ci: Fail publishing workflow if trying to release a duplicate version + bump to 6.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,12 +80,10 @@ jobs:
         uses: actions/setup-dotnet@v4
 
       # Publish all NuGet packages to NuGet.org
-      # Use --skip-duplicate to prevent errors if a package with the same version already exists.
-      # If you retry a failed workflow, already published packages will be skipped without error.
       - name: Publish NuGet package
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
-              dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+              dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json
           }
 
       - name: Upload Release Asset

--- a/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj
+++ b/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PackageId>Flagsmith</PackageId>
     <Title>Flagsmith</Title>
-    <Version>5.4.3</Version>
+    <Version>6.0.0</Version>
     <Authors>flagsmith</Authors>
     <Company>Flagsmith</Company>
     <PackageDescription>Client SDK for Flagsmith. Ship features with confidence using feature flags and remote config. Host yourself or use our hosted version at https://flagsmith.com/</PackageDescription>


### PR DESCRIPTION
This workflow run was meant to publish version 6.0.0 and succeeded: https://github.com/Flagsmith/flagsmith-dotnet-client/actions/runs/12350235990/job/34462737804

However, the last published version is still 5.4.3: https://www.nuget.org/packages/Flagsmith. This is because we didn't bump the version here before releasing: https://github.com/Flagsmith/flagsmith-dotnet-client/blob/137590cc3fd8d9c2b739d046618631f07ee1068f/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj#L10

The workflow succeeded because it uses `dotnet nuget push --skip-duplicate`. This is intended to handle partial failures when publishing multiple packages at once, which we don't want since we only have one package to publish.

This change also bumps the version to 6.0.0.

Note: this is completely untested!