### PR TITLE
fix!: Remove flag ID properties/methods

### DIFF
--- a/Flagsmith.FlagsmithClient/Flag.cs
+++ b/Flagsmith.FlagsmithClient/Flag.cs
@@ -15,8 +15,6 @@ namespace Flagsmith
             this.Value = value;
             this.Feature = feature;
         }
-        [JsonProperty("id")]
-        public int Id { get; private set; }
         [JsonProperty("feature")]
         private Feature Feature { get; set; }
 
@@ -26,10 +24,6 @@ namespace Flagsmith
         [JsonProperty("feature_state_value")]
         public string Value { get; private set; }
 
-        public int getFeatureId()
-        {
-            return this.Feature.Id;
-        }
         public string GetFeatureName()
         {
             return this.Feature.Name;

--- a/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj
+++ b/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj
@@ -7,7 +7,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PackageId>Flagsmith</PackageId>
     <Title>Flagsmith</Title>
-    <Version>6.0.0</Version>
+    <Version>7.0.0</Version>
     <Authors>flagsmith</Authors>
     <Company>Flagsmith</Company>
     <PackageDescription>Client SDK for Flagsmith. Ship features with confidence using feature flags and remote config. Host yourself or use our hosted version at https://flagsmith.com/</PackageDescription>

--- a/Flagsmith.FlagsmithClient/IFlag.cs
+++ b/Flagsmith.FlagsmithClient/IFlag.cs
@@ -2,11 +2,8 @@
 {
     public interface IFlag
     {
-        int Id { get; }
         bool Enabled { get; }
         string Value { get; }
-        int getFeatureId();
         string GetFeatureName();
-        string ToString();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Flagsmith/flagsmith-dotnet-client/issues/128

I considered making making `Id` nullable, but IMO there's no reason why ID is relevant at all for customers or SDK internals. Removing it is the most future-proof change.

`getFeatureId` is also not used anywhere. `ToString` makes no sense to have as part of the `IFlag` interface.