### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   create_nuget:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,33 +68,33 @@ jobs:
       - name: Validate package
         run: meziantou.validate-nuget-package (Get-ChildItem "${{ env.NuGetDirectory }}/*.nupkg") --excluded-rule-ids 101,111,74,72,61,12
 
-  # publish:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #       - create_nuget
-  #       - validate_nuget
-  #   steps:
-  #     # Download the NuGet package created in the previous job
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         name: nuget
-  #         path: ${{ env.NuGetDirectory }}
+  publish:
+    runs-on: ubuntu-latest
+    needs:
+        - create_nuget
+        - validate_nuget
+    steps:
+      # Download the NuGet package created in the previous job
+      - uses: actions/download-artifact@v4
+        with:
+          name: nuget
+          path: ${{ env.NuGetDirectory }}
 
-  #     # Install the .NET SDK indicated in the global.json file
-  #     - name: Setup .NET Core
-  #       uses: actions/setup-dotnet@v4
-  #       with:
-  #         dotnet-version: ${{ env.DOTNET_VERSION }}
+      # Install the .NET SDK indicated in the global.json file
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
 
-  #     # Publish all NuGet packages to NuGet.org
-  #     - name: Publish NuGet package
-  #       run: |
-  #         foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
-  #             dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json
-  #         }
+      # Publish all NuGet packages to NuGet.org
+      - name: Publish NuGet package
+        run: |
+          foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
+              dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json
+          }
 
-  #     - name: Upload Release Asset
-  #       uses: shogo82148/actions-upload-release-asset@v1
-  #       with:
-  #         upload_url: ${{ github.event.release.upload_url }}
-  #         asset_path: ${{ env.NuGetDirectory }}/*.nupkg
+      - name: Upload Release Asset
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ env.NuGetDirectory }}/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
   NuGetDirectory: ${{ github.workspace }}/nuget
-  DOTNET_VERSION: 7.0.x
+  DOTNET_VERSION: 8.0.x
 
 defaults:
   run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - published
+  push:
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -68,33 +69,33 @@ jobs:
       - name: Validate package
         run: meziantou.validate-nuget-package (Get-ChildItem "${{ env.NuGetDirectory }}/*.nupkg") --excluded-rule-ids 101,111,74,72,61,12
 
-  publish:
-    runs-on: ubuntu-latest
-    needs:
-        - create_nuget
-        - validate_nuget
-    steps:
-      # Download the NuGet package created in the previous job
-      - uses: actions/download-artifact@v4
-        with:
-          name: nuget
-          path: ${{ env.NuGetDirectory }}
+  # publish:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #       - create_nuget
+  #       - validate_nuget
+  #   steps:
+  #     # Download the NuGet package created in the previous job
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: nuget
+  #         path: ${{ env.NuGetDirectory }}
 
-      # Install the .NET SDK indicated in the global.json file
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+  #     # Install the .NET SDK indicated in the global.json file
+  #     - name: Setup .NET Core
+  #       uses: actions/setup-dotnet@v4
+  #       with:
+  #         dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      # Publish all NuGet packages to NuGet.org
-      - name: Publish NuGet package
-        run: |
-          foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
-              dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json
-          }
+  #     # Publish all NuGet packages to NuGet.org
+  #     - name: Publish NuGet package
+  #       run: |
+  #         foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
+  #             dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json
+  #         }
 
-      - name: Upload Release Asset
-        uses: shogo82148/actions-upload-release-asset@v1
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ env.NuGetDirectory }}/*.nupkg
+  #     - name: Upload Release Asset
+  #       uses: shogo82148/actions-upload-release-asset@v1
+  #       with:
+  #         upload_url: ${{ github.event.release.upload_url }}
+  #         asset_path: ${{ env.NuGetDirectory }}/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   release:
     types:
       - published
-  push:
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1


### PR DESCRIPTION
Fixes issue seen in release workflow [here](https://github.com/Flagsmith/flagsmith-dotnet-client/actions/runs/12777119892). 

I'm not too sure why it started failing but I think it's similar to other recent issues (see e.g. #130, #132) where things have changed in the underlying system that mean certain built in dotnet versions are no longer available. 

From what I can tell, we were trying to use 7.0.x on previous successful runs of the release workflow, but the library we're using to validate the package doesn't support 7.0.x so the only explanation is that it was falling back to some built in version of .net8.0. 