### PR TITLE
feat: Deprecate constructors with >1 parameter and IFlagsmithConfig interface. Add EnableLocalEvaluation and EnvironmentRefreshInterval properties

### DIFF
--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -21,10 +21,16 @@ namespace Flagsmith.FlagsmithClientTest
         {
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.JsonObject.ToString())
             });
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, enableClientSideEvaluation: true);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                EnableLocalEvaluation = true
+            };
+            _ = new FlagsmithClient(config);
             mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
         }
         [Fact]
@@ -35,13 +41,13 @@ namespace Flagsmith.FlagsmithClientTest
             {
                 { "/api/v1/environment-document/", new HttpResponseMessage
                     {
-                        StatusCode = System.Net.HttpStatusCode.OK,
+                        StatusCode = HttpStatusCode.OK,
                         Content = new StringContent(Fixtures.JsonObject.ToString())
                     }
                 },
                 { "/api/v1/flags/", new HttpResponseMessage
                     {
-                        StatusCode = System.Net.HttpStatusCode.OK,
+                        StatusCode = HttpStatusCode.OK,
                         Content = new StringContent(Fixtures.ApiFlagResponse)
                     }
                 }
@@ -49,7 +55,13 @@ namespace Flagsmith.FlagsmithClientTest
             var mockHttpClient = HttpMocker.MockHttpResponse(responses);
 
             // When
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, enableClientSideEvaluation: true, httpClient: mockHttpClient.Object);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                EnableLocalEvaluation = true
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
 
             // Then
             mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
@@ -62,10 +74,15 @@ namespace Flagsmith.FlagsmithClientTest
         {
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.ApiFlagResponse)
             });
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             var flags = (await flagsmithClientTest.GetEnvironmentFlags()).AllFlags();
             mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/flags/", Times.Once);
             Assert.True(flags[0].Enabled);
@@ -94,7 +111,13 @@ namespace Flagsmith.FlagsmithClientTest
             var mockHttpClient = HttpMocker.MockHttpResponse(responses);
 
             // When
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, enableClientSideEvaluation: true, httpClient: mockHttpClient.Object);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                EnableLocalEvaluation = true
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
 
             // Then
             mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
@@ -112,14 +135,20 @@ namespace Flagsmith.FlagsmithClientTest
 
             ThreadPool.SetMinThreads(numberOfThreads, numberOfThreads);
 
-            var mockHttpClient = HttpMocker.MockHttpResponse(System.Net.HttpStatusCode.OK, Fixtures.ApiIdentityResponse, false);
+            var mockHttpClient = HttpMocker.MockHttpResponse(HttpStatusCode.OK, Fixtures.ApiIdentityResponse, false);
 
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, cacheConfig: new CacheConfig(true));
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                CacheConfig = new CacheConfig(true)
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
 
             var token = new CancellationToken();
-            await Parallel.ForEachAsync(Enumerable.Range(1, numberOfThreads), token, async (item, token) =>
+            await Parallel.ForEachAsync(Enumerable.Range(1, numberOfThreads), token, async (item, _) =>
             {
-                var flags = (await flagsmithClientTest.GetIdentityFlags(item.ToString())).AllFlags();
+                (await flagsmithClientTest.GetIdentityFlags(item.ToString())).AllFlags();
             });
         }
         [Theory]
@@ -129,10 +158,15 @@ namespace Flagsmith.FlagsmithClientTest
         {
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.ApiIdentityResponse)
             });
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             var flags = (await flagsmithClientTest.GetIdentityFlags(identifier)).AllFlags();
             Assert.True(flags[0].Enabled);
             Assert.Equal("some-value", flags[0].Value);
@@ -145,10 +179,15 @@ namespace Flagsmith.FlagsmithClientTest
         {
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.ApiIdentityResponse)
             });
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             var traits = new List<ITrait> { new Trait("foo", "bar") };
 
 
@@ -164,13 +203,17 @@ namespace Flagsmith.FlagsmithClientTest
         {
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.JsonObject.ToString())
             });
 
-            var traits = new List<ITrait> { new Trait("foo", "bar") };
-
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, enableClientSideEvaluation: true, httpClient: mockHttpClient.Object);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                EnableLocalEvaluation = true
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
 
             _ = await flagsmithClientTest.GetIdentityFlags("identifier", new List<ITrait>() { new Trait("foo", "bar") });
@@ -182,13 +225,19 @@ namespace Flagsmith.FlagsmithClientTest
         {
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.JsonObject.ToString())
             });
 
             var traits = new List<ITrait> { new Trait("foo", "bar") };
 
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, enableClientSideEvaluation: true, httpClient: mockHttpClient.Object);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                EnableLocalEvaluation = true
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
 
             var flags = await flagsmithClientTest.GetIdentityFlags("overridden-id", traits);
@@ -200,7 +249,12 @@ namespace Flagsmith.FlagsmithClientTest
         public async Task TestRequestConnectionErrorRaisesFlagsmithApiError()
         {
             var mockHttpClient = HttpMocker.MockHttpThrowConnectionError();
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             await Assert.ThrowsAsync<FlagsmithAPIError>(async () => await flagsmithClientTest.GetEnvironmentFlags());
         }
         [Fact]
@@ -208,9 +262,14 @@ namespace Flagsmith.FlagsmithClientTest
         {
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.Forbidden,
+                StatusCode = HttpStatusCode.Forbidden,
             });
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             await Assert.ThrowsAsync<FlagsmithAPIError>(async () => await flagsmithClientTest.GetEnvironmentFlags());
         }
         [Fact]
@@ -219,10 +278,16 @@ namespace Flagsmith.FlagsmithClientTest
             var defaultFlag = new Flag(null, true, "some-default-value");
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent("[]")
             });
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, defaultFlagHandler: (string name) => defaultFlag);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                DefaultFlagHandler = _ => defaultFlag
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             var flags = await flagsmithClientTest.GetEnvironmentFlags();
             var flag = await flags.GetFlag("some_feature");
             Assert.True(flag.Enabled);
@@ -234,10 +299,16 @@ namespace Flagsmith.FlagsmithClientTest
             var defaultFlag = new Flag(null, true, "some-default-value");
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.ApiFlagResponse)
             });
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, defaultFlagHandler: (string name) => defaultFlag);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                DefaultFlagHandler = _ => defaultFlag
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             var flags = await flagsmithClientTest.GetEnvironmentFlags();
             var flag = await flags.GetFlag("some_feature");
             Assert.True(flag.Enabled);
@@ -249,10 +320,16 @@ namespace Flagsmith.FlagsmithClientTest
             var defaultFlag = new Flag(null, true, "some-default-value");
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent("{}")
             });
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, defaultFlagHandler: (string name) => defaultFlag);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                DefaultFlagHandler = _ => defaultFlag
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             var flags = await flagsmithClientTest.GetIdentityFlags("identifier");
             var flag = await flags.GetFlag("some_feature");
             Assert.True(flag.Enabled);
@@ -264,10 +341,16 @@ namespace Flagsmith.FlagsmithClientTest
             var defaultFlag = new Flag(null, true, "some-default-value");
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.ApiIdentityResponse)
             });
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, defaultFlagHandler: (string name) => defaultFlag);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                DefaultFlagHandler = _ => defaultFlag
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             var flags = await flagsmithClientTest.GetIdentityFlags("identifier");
             var flag = await flags.GetFlag("some_feature");
             Assert.True(flag.Enabled);
@@ -279,9 +362,15 @@ namespace Flagsmith.FlagsmithClientTest
             var defaultFlag = new Flag(null, true, "some-default-value");
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.Forbidden,
+                StatusCode = HttpStatusCode.Forbidden,
             });
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, defaultFlagHandler: (string name) => defaultFlag);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                DefaultFlagHandler = _ => defaultFlag
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             var flags = await flagsmithClientTest.GetEnvironmentFlags();
             var flag = await flags.GetFlag("some_feature");
             Assert.True(flag.Enabled);
@@ -296,11 +385,16 @@ namespace Flagsmith.FlagsmithClientTest
 
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK
+                StatusCode = HttpStatusCode.OK
             });
-            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object
+            };
+            var flagsmithClient = new FlagsmithClient(config);
 
-            var flags = await flagsmithClient.GetIdentityFlags(identifier, traits);
+            await flagsmithClient.GetIdentityFlags(identifier, traits);
 
             mockHttpClient.VerifyHttpRequest(HttpMethod.Post, "/api/v1/identities/", Times.Once);
             // TODO: verify the body is correct - I've verified manually but can't verify programmatically
@@ -312,13 +406,19 @@ namespace Flagsmith.FlagsmithClientTest
             // Given
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.JsonObject.ToString())
             });
-            FlagsmithClient flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, enableClientSideEvaluation: true);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                EnableLocalEvaluation = true
+            };
+            var flagsmithClient = new FlagsmithClient(config);
 
             // When
-            List<ISegment> segments = flagsmithClient.GetIdentitySegments("identifier");
+            var segments = flagsmithClient.GetIdentitySegments("identifier");
 
             // Then
             Assert.Empty(segments);
@@ -330,16 +430,22 @@ namespace Flagsmith.FlagsmithClientTest
             // Given
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.JsonObject.ToString())
             });
-            FlagsmithClient flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, enableClientSideEvaluation: true);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                EnableLocalEvaluation = true
+            };
+            var flagsmithClient = new FlagsmithClient(config);
 
-            string identifier = "identifier";
-            List<ITrait> traits = new List<ITrait>() { new Trait(traitKey: "foo", traitValue: "bar") };
+            var identifier = "identifier";
+            var traits = new List<ITrait>() { new Trait(traitKey: "foo", traitValue: "bar") };
 
             // When
-            List<ISegment> segments = flagsmithClient.GetIdentitySegments(identifier, traits);
+            var segments = flagsmithClient.GetIdentitySegments(identifier, traits);
 
             // Then
             Assert.Single(segments);
@@ -354,22 +460,26 @@ namespace Flagsmith.FlagsmithClientTest
             {
                 { "/api/v1/environment-document/", new HttpResponseMessage
                     {
-                        StatusCode = System.Net.HttpStatusCode.OK,
+                        StatusCode = HttpStatusCode.OK,
                         Content = new StringContent(Fixtures.JsonObject.ToString())
                     }
                 },
                 { "/api/v1/flags/", new HttpResponseMessage
                     {
-                        StatusCode = System.Net.HttpStatusCode.OK,
+                        StatusCode = HttpStatusCode.OK,
                         Content = new StringContent(Fixtures.ApiFlagResponse)
                     }
                 }
             };
             var mockHttpClient = HttpMocker.MockHttpResponse(responses);
-            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey,
-                httpClient: mockHttpClient.Object,
-                enableClientSideEvaluation: true,
-                cacheConfig: new CacheConfig(true));
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                EnableLocalEvaluation = true,
+                CacheConfig = new CacheConfig(true)
+            };
+            var flagsmithClient = new FlagsmithClient(config);
 
             // When
             var flags = flagsmithClient.GetEnvironmentFlags().Result;
@@ -383,19 +493,21 @@ namespace Flagsmith.FlagsmithClientTest
         public async Task TestOfflineMode_IntegrationTest()
         {
             // Given
-            var environment = JObject
+            JObject
                 .Parse(File.ReadAllText("../../../data/offline-environment.json"))
                 .ToObject<EnvironmentModel>();
 
-            var expectedPath = "../../../data/offline-environment.json";
+            const string expectedPath = "../../../data/offline-environment.json";
 
             var localFileHandler = new LocalFileHandler(expectedPath);
 
             // When
-            var flagsmithClient = new FlagsmithClient(
-                offlineMode: true,
-                offlineHandler: localFileHandler
-            );
+            var config = new FlagsmithConfiguration
+            {
+                OfflineMode = true,
+                OfflineHandler = localFileHandler
+            };
+            var flagsmithClient = new FlagsmithClient(config);
 
             // Then
             // we can request the flags from the client successfully
@@ -415,10 +527,10 @@ namespace Flagsmith.FlagsmithClientTest
         {
             // Given
             var environment = JObject
-                .Parse(File.ReadAllText("../../../data/offline-environment.json"))
+                .Parse(await File.ReadAllTextAsync("../../../data/offline-environment.json"))
                 .ToObject<EnvironmentModel>();
 
-            var apiUrl = "http://some.flagsmith.com/api/v1/";
+            const string apiUrl = "http://some.flagsmith.com/api/v1/";
             var mockOfflineHandler = new Mock<BaseOfflineHandler>();
             var mockFlagsmithClient = new Mock<IFlagsmithClient>();
 
@@ -429,12 +541,14 @@ namespace Flagsmith.FlagsmithClientTest
                 StatusCode = HttpStatusCode.InternalServerError
             });
 
-            var flagsmithClientTest = new FlagsmithClient(
-                environmentKey: "some-key",
-                httpClient: mockHttpClient.Object,
-                apiUrl: apiUrl,
-                offlineHandler: mockOfflineHandler.Object
-                );
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = "some-key",
+                HttpClient = mockHttpClient.Object,
+                ApiUri = new Uri(apiUrl),
+                OfflineHandler = mockOfflineHandler.Object
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
 
             // When
             mockFlagsmithClient.Setup(f => f.GetEnvironmentFlags()).ReturnsAsync(await flagsmithClientTest.GetEnvironmentFlags());
@@ -472,7 +586,13 @@ namespace Flagsmith.FlagsmithClientTest
             });
 
             // When
-            FlagsmithClient flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, offlineHandler: mockOfflineHandler.Object);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                OfflineHandler = mockOfflineHandler.Object
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
 
             // Then
             var environmentFlags = await flagsmithClientTest.GetEnvironmentFlags();
@@ -486,10 +606,14 @@ namespace Flagsmith.FlagsmithClientTest
         public void TestCannotUseOfflineModeWithoutOfflineHandler()
         {
             // When
-            Action createFlagsmith = () => new FlagsmithClient(offlineMode: true, offlineHandler: null);
+            void CreateFlagsmith()
+            {
+                var config = new FlagsmithConfiguration { OfflineMode = true, OfflineHandler = null };
+                _ = new FlagsmithClient(config);
+            }
 
             // Then
-            var exception = Assert.Throws<Exception>(() => createFlagsmith());
+            var exception = Assert.Throws<Exception>(CreateFlagsmith);
             Assert.Equal("ValueError: offlineHandler must be provided to use offline mode.", exception.Message);
         }
 
@@ -502,13 +626,14 @@ namespace Flagsmith.FlagsmithClientTest
             var localFileHandler = new LocalFileHandler(expectedPath);
 
             // When
-            Action createFlagsmith = () => new FlagsmithClient(
-                    offlineHandler: localFileHandler,
-                    defaultFlagHandler: (string name) => defaultFlag
-                );
+            void CreateFlagsmith()
+            {
+                var config = new FlagsmithConfiguration { OfflineHandler = localFileHandler, DefaultFlagHandler = _ => defaultFlag };
+                _ = new FlagsmithClient(config);
+            }
 
             // Then
-            var exception = Assert.Throws<Exception>(() => createFlagsmith());
+            var exception = Assert.Throws<Exception>(CreateFlagsmith);
             Assert.Equal("ValueError: Cannot use both defaultFlagHandler and offlineHandler.", exception.Message);
         }
 
@@ -516,10 +641,10 @@ namespace Flagsmith.FlagsmithClientTest
         public void TestCannotCreateFlagsmithClientInRemoteEvaluationWithoutAPIKey()
         {
             // When
-            Action createFlagsmith = () => new FlagsmithClient();
+            void CreateFlagsmith() => _ = new FlagsmithClient(new FlagsmithConfiguration());
 
             // Then
-            var exception = Assert.Throws<Exception>(() => createFlagsmith());
+            var exception = Assert.Throws<Exception>(CreateFlagsmith);
             Assert.Equal("ValueError: environmentKey is required", exception.Message);
         }
 
@@ -536,10 +661,16 @@ namespace Flagsmith.FlagsmithClientTest
             // Given
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
-                StatusCode = System.Net.HttpStatusCode.OK,
+                StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.ApiFlagResponseWithTenFlags)
             });
-            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, enableAnalytics: true);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object,
+                EnableAnalytics = true
+            };
+            var flagsmithClientTest = new FlagsmithClient(config);
             var flags = await flagsmithClientTest.GetEnvironmentFlags();
             var featuresDictionary = new Dictionary<string, int>();
 
@@ -558,13 +689,12 @@ namespace Flagsmith.FlagsmithClientTest
             var tasks = new Task[numberOfThreads];
 
             // Create numberOfThreads threads.
-            for (int i = 0; i < numberOfThreads; i++)
+            for (var i = 0; i < numberOfThreads; i++)
             {
-                var local = i;
                 string[] features = new string[callsPerThread];
 
                 // Prepare an array of feature names of length callsPerThread.
-                for (int j = 0; j < callsPerThread; j++)
+                for (var j = 0; j < callsPerThread; j++)
                 {
                     // The feature names are randomly selected from the featuresDictionary and added to the 
                     // list of features, which represents the features that have been evaluated.  
@@ -589,7 +719,7 @@ namespace Flagsmith.FlagsmithClientTest
             await Task.WhenAll(tasks);
 
             // Then
-            Dictionary<string, int> analyticsData = flagsmithClientTest.aggregatedAnalytics;
+            var analyticsData = flagsmithClientTest.aggregatedAnalytics;
             int totalCallsMade = 0;
             foreach (var feature in featuresDictionary)
             {
@@ -604,7 +734,6 @@ namespace Flagsmith.FlagsmithClientTest
         {
             // Given
             string identifier = "transient_identity";
-            bool transient = true;
             var traits = new List<ITrait> { new Trait("some_trait", "some_value") };
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
@@ -612,8 +741,13 @@ namespace Flagsmith.FlagsmithClientTest
                 Content = new StringContent(Fixtures.ApiTransientIdentityResponse)
             });
             // When
-            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
-            var identityFlags = await flagsmithClient.GetIdentityFlags(identifier, traits, transient);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object
+            };
+            var flagsmithClient = new FlagsmithClient(config);
+            var identityFlags = await flagsmithClient.GetIdentityFlags(identifier, traits, true);
             // Then
             mockHttpClient.VerifyHttpRequest(HttpMethod.Post, "/api/v1/identities/", Times.Once, "{\"identifier\":\"transient_identity\",\"traits\":[{\"trait_key\":\"some_trait\",\"trait_value\":\"some_value\",\"transient\":false}],\"transient\":true}");
             Assert.True(await identityFlags.IsFeatureEnabled("some_feature"));
@@ -633,7 +767,12 @@ namespace Flagsmith.FlagsmithClientTest
                 Content = new StringContent(Fixtures.ApiIdentityWithTransientTraitsResponse)
             });
             // When
-            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object
+            };
+            var flagsmithClient = new FlagsmithClient(config);
             var identityFlags = await flagsmithClient.GetIdentityFlags(identifier, traits);
             // Then
             mockHttpClient.VerifyHttpRequest(HttpMethod.Post, "/api/v1/identities/", Times.Once, "{\"identifier\":\"test_identity_with_transient_traits\",\"traits\":[{\"trait_key\":\"transient_trait\",\"trait_value\":\"transient_trait_value\",\"transient\":true}],\"transient\":false}");
@@ -645,20 +784,19 @@ namespace Flagsmith.FlagsmithClientTest
         {
             // Given
             string identifier = "transient_identity";
-            bool transient = true;
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.OK,
                 Content = new StringContent(Fixtures.ApiTransientIdentityResponse)
             });
-            var queryParams = new Dictionary<string, string>
-            {
-                { "identifier", "transient_identity" },
-                { "transient", "True" }
-            };
             // When
-            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
-            var identityFlags = await flagsmithClient.GetIdentityFlags(identifier, null, transient);
+            var config = new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                HttpClient = mockHttpClient.Object
+            };
+            var flagsmithClient = new FlagsmithClient(config);
+            var identityFlags = await flagsmithClient.GetIdentityFlags(identifier, null, true);
             // Then
             mockHttpClient.VerifyHttpRequest(HttpMethod.Post, "/api/v1/identities/", Times.Once, "{\"identifier\":\"transient_identity\",\"traits\":[],\"transient\":true}");
             Assert.True(await identityFlags.IsFeatureEnabled("some_feature"));

--- a/Flagsmith.Client.Test/FlagsmithTestDeprecated.cs
+++ b/Flagsmith.Client.Test/FlagsmithTestDeprecated.cs
@@ -1,0 +1,668 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FlagsmithEngine.Environment.Models;
+using Moq;
+using Newtonsoft.Json.Linq;
+using OfflineHandler;
+using Xunit;
+
+namespace Flagsmith.FlagsmithClientTest
+{
+    public class FlagsmithTestDeprecated
+    {
+        [Fact]
+        public void TestFlagsmithStartsPollingManagerOnInitIfEnabled()
+        {
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.JsonObject.ToString())
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, enableClientSideEvaluation: true);
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
+        }
+        [Fact]
+        public async void TestUpdateEnvironmentSetsEnvironment()
+        {
+            // Given
+            var responses = new Dictionary<string, HttpResponseMessage>
+            {
+                { "/api/v1/environment-document/", new HttpResponseMessage
+                    {
+                        StatusCode = System.Net.HttpStatusCode.OK,
+                        Content = new StringContent(Fixtures.JsonObject.ToString())
+                    }
+                },
+                { "/api/v1/flags/", new HttpResponseMessage
+                    {
+                        StatusCode = System.Net.HttpStatusCode.OK,
+                        Content = new StringContent(Fixtures.ApiFlagResponse)
+                    }
+                }
+            };
+            var mockHttpClient = HttpMocker.MockHttpResponse(responses);
+
+            // When
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, enableClientSideEvaluation: true, httpClient: mockHttpClient.Object);
+
+            // Then
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
+            await flagsmithClientTest.GetEnvironmentFlags();
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/flags/", Times.Never);
+        }
+        [Fact]
+        public async Task TestGetEnvironmentFlagsCallsApiWhenNoLocalEnvironment()
+        {
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiFlagResponse)
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var flags = (await flagsmithClientTest.GetEnvironmentFlags()).AllFlags();
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/flags/", Times.Once);
+            Assert.True(flags[0].Enabled);
+            Assert.Equal("some-value", flags[0].Value);
+            Assert.Equal("some_feature", flags[0].GetFeatureName());
+        }
+        [Fact]
+        public async Task TestGetEnvironmentFlagsUsesLocalEnvironmentWhenAvailable()
+        {
+            // Given
+            var responses = new Dictionary<string, HttpResponseMessage>
+            {
+                { "/api/v1/environment-document/", new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        Content = new StringContent(Fixtures.JsonObject.ToString())
+                    }
+                },
+                { "/api/v1/flags/", new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        Content = new StringContent(Fixtures.ApiFlagResponse)
+                    }
+                }
+            };
+            var mockHttpClient = HttpMocker.MockHttpResponse(responses);
+
+            // When
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, enableClientSideEvaluation: true, httpClient: mockHttpClient.Object);
+
+            // Then
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
+            var flags = (await flagsmithClientTest.GetEnvironmentFlags()).AllFlags();
+            var fs = Fixtures.Environment.FeatureStates[0];
+            Assert.Equal(fs.Enabled, flags[0].Enabled);
+            Assert.Equal(fs.GetValue(), flags[0].Value);
+            Assert.Equal(fs.Feature.Name, flags[0].GetFeatureName());
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
+        }
+        [Fact]
+        public async Task TestThatCacheDictionaryDoesNotThrowUnderLoad()
+        {
+            const int numberOfThreads = 500;
+
+            ThreadPool.SetMinThreads(numberOfThreads, numberOfThreads);
+
+            var mockHttpClient = HttpMocker.MockHttpResponse(System.Net.HttpStatusCode.OK, Fixtures.ApiIdentityResponse, false);
+
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, cacheConfig: new CacheConfig(true));
+
+            var token = new CancellationToken();
+            await Parallel.ForEachAsync(Enumerable.Range(1, numberOfThreads), token, async (item, token) =>
+            {
+                var flags = (await flagsmithClientTest.GetIdentityFlags(item.ToString())).AllFlags();
+            });
+        }
+        [Theory]
+        [InlineData("identifier", "{\"identifier\":\"identifier\",\"traits\":[],\"transient\":false}")]
+        [InlineData("identifier&h=g", "{\"identifier\":\"identifier&h=g\",\"traits\":[],\"transient\":false}")]
+        public async Task TestGetIdentityFlagsCallsPostApiWhenNoLocalEnvironmentNoTraits(string identifier, string expectedJson)
+        {
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiIdentityResponse)
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var flags = (await flagsmithClientTest.GetIdentityFlags(identifier)).AllFlags();
+            Assert.True(flags[0].Enabled);
+            Assert.Equal("some-value", flags[0].Value);
+            Assert.Equal("some_feature", flags[0].GetFeatureName());
+
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Post, "/api/v1/identities/", Times.Once, expectedJson);
+        }
+        [Fact]
+        public async Task TestGetIdentityFlagsCallsPostApiWhenNoLocalEnvironmentWithTraits()
+        {
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiIdentityResponse)
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var traits = new List<ITrait> { new Trait("foo", "bar") };
+
+
+            var flags = (await flagsmithClientTest.GetIdentityFlags("identifier", traits)).AllFlags();
+            Assert.True(flags[0].Enabled);
+            Assert.Equal("some-value", flags[0].Value);
+            Assert.Equal("some_feature", flags[0].GetFeatureName());
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Post, "/api/v1/identities/", Times.Once);
+
+        }
+        [Fact]
+        public async Task TestGetIdentityFlagsUsesLocalEnvironmentWhenAvailable()
+        {
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.JsonObject.ToString())
+            });
+
+            var traits = new List<ITrait> { new Trait("foo", "bar") };
+
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, enableClientSideEvaluation: true, httpClient: mockHttpClient.Object);
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
+
+            _ = await flagsmithClientTest.GetIdentityFlags("identifier", new List<ITrait>() { new Trait("foo", "bar") });
+
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
+        }
+        [Fact]
+        public async Task TestGetIdentityFlagsUsesLocalIdentityOverridesWhenAvailable()
+        {
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.JsonObject.ToString())
+            });
+
+            var traits = new List<ITrait> { new Trait("foo", "bar") };
+
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, enableClientSideEvaluation: true, httpClient: mockHttpClient.Object);
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/environment-document/", Times.Once);
+
+            var flags = await flagsmithClientTest.GetIdentityFlags("overridden-id", traits);
+            var flag = await flags.GetFlag("some_feature");
+            Assert.False(flag.Enabled);
+            Assert.Equal("some-overridden-value", flag.Value);
+        }
+        [Fact]
+        public async Task TestRequestConnectionErrorRaisesFlagsmithApiError()
+        {
+            var mockHttpClient = HttpMocker.MockHttpThrowConnectionError();
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            await Assert.ThrowsAsync<FlagsmithAPIError>(async () => await flagsmithClientTest.GetEnvironmentFlags());
+        }
+        [Fact]
+        public async Task TestNon200ResponseRaisesFlagsmithApiError()
+        {
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.Forbidden,
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            await Assert.ThrowsAsync<FlagsmithAPIError>(async () => await flagsmithClientTest.GetEnvironmentFlags());
+        }
+        [Fact]
+        public async Task TestDefaultFlagIsUsedWhenNoEnvironmentFlagsReturned()
+        {
+            var defaultFlag = new Flag(null, true, "some-default-value");
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent("[]")
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, defaultFlagHandler: (string name) => defaultFlag);
+            var flags = await flagsmithClientTest.GetEnvironmentFlags();
+            var flag = await flags.GetFlag("some_feature");
+            Assert.True(flag.Enabled);
+            Assert.Equal("some-default-value", flag.Value);
+        }
+        [Fact]
+        public async Task TestDefaultFlagIsNotUsedWhenEnvironmentFlagsReturned()
+        {
+            var defaultFlag = new Flag(null, true, "some-default-value");
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiFlagResponse)
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, defaultFlagHandler: (string name) => defaultFlag);
+            var flags = await flagsmithClientTest.GetEnvironmentFlags();
+            var flag = await flags.GetFlag("some_feature");
+            Assert.True(flag.Enabled);
+            Assert.NotEqual("some-default-value", flag.Value);
+        }
+        [Fact]
+        public async Task TestDefaultFlagIsUsedWhenNoIdentityFlagsReturned()
+        {
+            var defaultFlag = new Flag(null, true, "some-default-value");
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent("{}")
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, defaultFlagHandler: (string name) => defaultFlag);
+            var flags = await flagsmithClientTest.GetIdentityFlags("identifier");
+            var flag = await flags.GetFlag("some_feature");
+            Assert.True(flag.Enabled);
+            Assert.Equal("some-default-value", flag.Value);
+        }
+        [Fact]
+        public async Task TestDefaultFlagIsNotUsedWhenIdentityFlagsReturned()
+        {
+            var defaultFlag = new Flag(null, true, "some-default-value");
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiIdentityResponse)
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, defaultFlagHandler: (string name) => defaultFlag);
+            var flags = await flagsmithClientTest.GetIdentityFlags("identifier");
+            var flag = await flags.GetFlag("some_feature");
+            Assert.True(flag.Enabled);
+            Assert.NotEqual("some-default-value", flag.Value);
+        }
+        [Fact]
+        public async Task TestDefaultFlagsAreUsedIfApiErrorAndDefaultFlagHandlerGiven()
+        {
+            var defaultFlag = new Flag(null, true, "some-default-value");
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.Forbidden,
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, defaultFlagHandler: (string name) => defaultFlag);
+            var flags = await flagsmithClientTest.GetEnvironmentFlags();
+            var flag = await flags.GetFlag("some_feature");
+            Assert.True(flag.Enabled);
+            Assert.Equal("some-default-value", flag.Value);
+        }
+
+        [Fact]
+        public async Task TestGetIdentityFlagsSendsTraits()
+        {
+            string identifier = "identifier";
+            var traits = new List<ITrait>() { new Trait("foo", "bar"), new Trait("ifoo", 1) };
+
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK
+            });
+            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+
+            var flags = await flagsmithClient.GetIdentityFlags(identifier, traits);
+
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Post, "/api/v1/identities/", Times.Once);
+            // TODO: verify the body is correct - I've verified manually but can't verify programmatically
+        }
+
+        [Fact]
+        public void TestGetIdentitySegmentsNoTraits()
+        {
+            // Given
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.JsonObject.ToString())
+            });
+            FlagsmithClient flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, enableClientSideEvaluation: true);
+
+            // When
+            List<ISegment> segments = flagsmithClient.GetIdentitySegments("identifier");
+
+            // Then
+            Assert.Empty(segments);
+        }
+
+        [Fact]
+        public void TestGetIdentitySegmentsWithValidTrait()
+        {
+            // Given
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.JsonObject.ToString())
+            });
+            FlagsmithClient flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, enableClientSideEvaluation: true);
+
+            string identifier = "identifier";
+            List<ITrait> traits = new List<ITrait>() { new Trait(traitKey: "foo", traitValue: "bar") };
+
+            // When
+            List<ISegment> segments = flagsmithClient.GetIdentitySegments(identifier, traits);
+
+            // Then
+            Assert.Single(segments);
+            Assert.Equal("Test segment", segments[0].Name);
+        }
+
+        [Fact]
+        public void TestFlagsmithClientWithCacheInitialization()
+        {
+            // Given
+            var responses = new Dictionary<string, HttpResponseMessage>
+            {
+                { "/api/v1/environment-document/", new HttpResponseMessage
+                    {
+                        StatusCode = System.Net.HttpStatusCode.OK,
+                        Content = new StringContent(Fixtures.JsonObject.ToString())
+                    }
+                },
+                { "/api/v1/flags/", new HttpResponseMessage
+                    {
+                        StatusCode = System.Net.HttpStatusCode.OK,
+                        Content = new StringContent(Fixtures.ApiFlagResponse)
+                    }
+                }
+            };
+            var mockHttpClient = HttpMocker.MockHttpResponse(responses);
+            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey,
+                httpClient: mockHttpClient.Object,
+                enableClientSideEvaluation: true,
+                cacheConfig: new CacheConfig(true));
+
+            // When
+            var flags = flagsmithClient.GetEnvironmentFlags().Result;
+
+            // Then
+            Assert.NotNull(flags);
+        }
+
+
+        [Fact]
+        public async Task TestOfflineMode_IntegrationTest()
+        {
+            // Given
+            var environment = JObject
+                .Parse(File.ReadAllText("../../../data/offline-environment.json"))
+                .ToObject<EnvironmentModel>();
+
+            var expectedPath = "../../../data/offline-environment.json";
+
+            var localFileHandler = new LocalFileHandler(expectedPath);
+
+            // When
+            var flagsmithClient = new FlagsmithClient(
+                offlineMode: true,
+                offlineHandler: localFileHandler
+            );
+
+            // Then
+            // we can request the flags from the client successfully
+            var environmentFlags = await flagsmithClient.GetEnvironmentFlags();
+            var flag = await environmentFlags.GetFlag("some_feature");
+            Assert.True(flag.Enabled);
+            Assert.Equal("offline-value", flag.Value);
+
+            var identityFlags = await flagsmithClient.GetIdentityFlags("identity");
+            flag = await identityFlags.GetFlag("some_feature");
+            Assert.True(flag.Enabled);
+            Assert.Equal("offline-value", flag.Value);
+        }
+
+        [Fact]
+        public async Task TestFlagsmithUsesOfflineHandlerIfSetAndNoAPIResponse()
+        {
+            // Given
+            var environment = JObject
+                .Parse(File.ReadAllText("../../../data/offline-environment.json"))
+                .ToObject<EnvironmentModel>();
+
+            var apiUrl = "http://some.flagsmith.com/api/v1/";
+            var mockOfflineHandler = new Mock<BaseOfflineHandler>();
+            var mockFlagsmithClient = new Mock<IFlagsmithClient>();
+
+            mockOfflineHandler.Setup(h => h.GetEnvironment()).Returns(environment);
+
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.InternalServerError
+            });
+
+            var flagsmithClientTest = new FlagsmithClient(
+                environmentKey: "some-key",
+                httpClient: mockHttpClient.Object,
+                apiUrl: apiUrl,
+                offlineHandler: mockOfflineHandler.Object
+                );
+
+            // When
+            mockFlagsmithClient.Setup(f => f.GetEnvironmentFlags()).ReturnsAsync(await flagsmithClientTest.GetEnvironmentFlags());
+            mockFlagsmithClient.Setup(f => f.GetIdentityFlags("identity")).ReturnsAsync(await flagsmithClientTest.GetIdentityFlags("identity"));
+
+            // Then
+            mockOfflineHandler.Verify(h => h.GetEnvironment(), Times.AtMost(2));
+            mockFlagsmithClient.Verify(h => h.GetEnvironmentFlags(), Times.AtMostOnce());
+            mockFlagsmithClient.Verify(h => h.GetIdentityFlags("identity"), Times.AtMostOnce());
+
+            var environmentFlags = await flagsmithClientTest.GetEnvironmentFlags();
+            var identityFlags = await flagsmithClientTest.GetIdentityFlags("identity");
+
+            Assert.True(await environmentFlags.IsFeatureEnabled("some_feature"));
+            Assert.Equal("offline-value", await environmentFlags.GetFeatureValue("some_feature"));
+
+            Assert.True(await identityFlags.IsFeatureEnabled("some_feature"));
+            Assert.Equal("offline-value", await identityFlags.GetFeatureValue("some_feature"));
+        }
+
+        [Fact]
+        public async Task TestFlagsmithUsesTheAPIResponseEvenIfTheOfflineHandlerIsSet()
+        {
+            // Given
+            var environment = JObject
+                .Parse(File.ReadAllText("../../../data/offline-environment.json"))
+                .ToObject<EnvironmentModel>();
+
+            var mockOfflineHandler = new Mock<BaseOfflineHandler>();
+            mockOfflineHandler.Setup(h => h.GetEnvironment()).Returns(environment);
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiFlagResponse),
+            });
+
+            // When
+            FlagsmithClient flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, offlineHandler: mockOfflineHandler.Object);
+
+            // Then
+            var environmentFlags = await flagsmithClientTest.GetEnvironmentFlags();
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Get, "/api/v1/flags/", Times.Once);
+            Assert.True(await environmentFlags.IsFeatureEnabled("some_feature"));
+            Assert.NotEqual("offline-value", await environmentFlags.GetFeatureValue("some_feature"));
+            Assert.Equal("some-value", await environmentFlags.GetFeatureValue("some_feature"));
+        }
+
+        [Fact]
+        public void TestCannotUseOfflineModeWithoutOfflineHandler()
+        {
+            // When
+            Action createFlagsmith = () => new FlagsmithClient(offlineMode: true, offlineHandler: null);
+
+            // Then
+            var exception = Assert.Throws<Exception>(() => createFlagsmith());
+            Assert.Equal("ValueError: offlineHandler must be provided to use offline mode.", exception.Message);
+        }
+
+        [Fact]
+        public void TestCannotUseBothDefaultHandlerAndOfflineHandler()
+        {
+            // Given
+            var defaultFlag = new Flag(null, true, "some-default-value");
+            var expectedPath = "../../../data/offline-environment.json";
+            var localFileHandler = new LocalFileHandler(expectedPath);
+
+            // When
+            Action createFlagsmith = () => new FlagsmithClient(
+                    offlineHandler: localFileHandler,
+                    defaultFlagHandler: (string name) => defaultFlag
+                );
+
+            // Then
+            var exception = Assert.Throws<Exception>(() => createFlagsmith());
+            Assert.Equal("ValueError: Cannot use both defaultFlagHandler and offlineHandler.", exception.Message);
+        }
+
+        [Fact]
+        public void TestCannotCreateFlagsmithClientInRemoteEvaluationWithoutAPIKey()
+        {
+            // When
+            Action createFlagsmith = () => new FlagsmithClient();
+
+            // Then
+            var exception = Assert.Throws<Exception>(() => createFlagsmith());
+            Assert.Equal("ValueError: environmentKey is required", exception.Message);
+        }
+
+        [Fact]
+        /// <summary>
+        /// Test that analytics data is consistent with concurrent calls to get flags.
+        /// A huge number of threads are spawned to ensure that the issues related with
+        /// concurrency are systematically reproduced even in machines with good resources.
+        /// Tested with a MacBook Pro M2 with 16GB of RAM and a Core i7 PC with 48 GB of RAM.
+        /// The increment on execution time in the CI runners is not significant.
+        /// </summary>
+        public async Task TestAnalyticsDataConsistencyWithConcurrentCallsToGetFlags()
+        {
+            // Given
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiFlagResponseWithTenFlags)
+            });
+            var flagsmithClientTest = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object, enableAnalytics: true);
+            var flags = await flagsmithClientTest.GetEnvironmentFlags();
+            var featuresDictionary = new Dictionary<string, int>();
+
+            const int numberOfFeatures = 10;
+            const int numberOfThreads = 1000;
+            const int callsPerThread = 1000;
+
+            ThreadPool.SetMinThreads(numberOfThreads, numberOfThreads);
+
+            for (int i = 1; i <= numberOfFeatures; i++)
+            {
+                featuresDictionary.TryAdd($"Feature_{i}", 0);
+            }
+
+            // When 
+            var tasks = new Task[numberOfThreads];
+
+            // Create numberOfThreads threads.
+            for (int i = 0; i < numberOfThreads; i++)
+            {
+                var local = i;
+                string[] features = new string[callsPerThread];
+
+                // Prepare an array of feature names of length callsPerThread.
+                for (int j = 0; j < callsPerThread; j++)
+                {
+                    // The feature names are randomly selected from the featuresDictionary and added to the 
+                    // list of features, which represents the features that have been evaluated.  
+                    string featureName = $"Feature_{new Random().Next(1, featuresDictionary.Count + 1)}";
+                    features[j] = featureName;
+
+                    // The relevant key in the featuresDictionary is incremented to simulate an evaluation
+                    // to track for that feature. 
+                    featuresDictionary[featureName]++;
+                }
+
+                // Each thread will call IsFeatureEnabled for callsPerThread times.
+                tasks[i] = Task.Run(async () =>
+                {
+                    foreach (var feature in features)
+                    {
+                        await flags.IsFeatureEnabled(feature);
+                    }
+                });
+            }
+
+            await Task.WhenAll(tasks);
+
+            // Then
+            Dictionary<string, int> analyticsData = flagsmithClientTest.aggregatedAnalytics;
+            int totalCallsMade = 0;
+            foreach (var feature in featuresDictionary)
+            {
+                totalCallsMade += analyticsData[feature.Key];
+                Assert.Equal(feature.Value, analyticsData[feature.Key]);
+            }
+            Assert.Equal(numberOfThreads * callsPerThread, totalCallsMade);
+        }
+
+        [Fact]
+        public async Task TestGetIdentityFlagsTransientIdentityCallsExpected()
+        {
+            // Given
+            string identifier = "transient_identity";
+            bool transient = true;
+            var traits = new List<ITrait> { new Trait("some_trait", "some_value") };
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiTransientIdentityResponse)
+            });
+            // When
+            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var identityFlags = await flagsmithClient.GetIdentityFlags(identifier, traits, transient);
+            // Then
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Post, "/api/v1/identities/", Times.Once, "{\"identifier\":\"transient_identity\",\"traits\":[{\"trait_key\":\"some_trait\",\"trait_value\":\"some_value\",\"transient\":false}],\"transient\":true}");
+            Assert.True(await identityFlags.IsFeatureEnabled("some_feature"));
+            Assert.Equal("some-identity-trait-value", await identityFlags.GetFeatureValue("some_feature"));
+        }
+
+        [Fact]
+        public async Task TestGetIdentityFlagsTransientTraitKeysCallsExpected()
+        {
+            // Given
+            string identifier = "test_identity_with_transient_traits";
+            var traits = new List<ITrait> { new Trait("transient_trait", "transient_trait_value", true) };
+
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiIdentityWithTransientTraitsResponse)
+            });
+            // When
+            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var identityFlags = await flagsmithClient.GetIdentityFlags(identifier, traits);
+            // Then
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Post, "/api/v1/identities/", Times.Once, "{\"identifier\":\"test_identity_with_transient_traits\",\"traits\":[{\"trait_key\":\"transient_trait\",\"trait_value\":\"transient_trait_value\",\"transient\":true}],\"transient\":false}");
+            Assert.True(await identityFlags.IsFeatureEnabled("some_feature"));
+            Assert.Equal("some-transient-trait-value", await identityFlags.GetFeatureValue("some_feature"));
+        }
+        [Fact]
+        public async Task TestGetIdentityFlagsTransientIdentityWithoutTraitCallsExpected()
+        {
+            // Given
+            string identifier = "transient_identity";
+            bool transient = true;
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiTransientIdentityResponse)
+            });
+            var queryParams = new Dictionary<string, string>
+            {
+                { "identifier", "transient_identity" },
+                { "transient", "True" }
+            };
+            // When
+            var flagsmithClient = new FlagsmithClient(Fixtures.ApiKey, httpClient: mockHttpClient.Object);
+            var identityFlags = await flagsmithClient.GetIdentityFlags(identifier, null, transient);
+            // Then
+            mockHttpClient.VerifyHttpRequest(HttpMethod.Post, "/api/v1/identities/", Times.Once, "{\"identifier\":\"transient_identity\",\"traits\":[],\"transient\":true}");
+            Assert.True(await identityFlags.IsFeatureEnabled("some_feature"));
+            Assert.Equal("some-identity-trait-value", await identityFlags.GetFeatureValue("some_feature"));
+        }
+    }
+}

--- a/Flagsmith.Client.Test/PollingManagerTest.cs
+++ b/Flagsmith.Client.Test/PollingManagerTest.cs
@@ -18,7 +18,7 @@ namespace Flagsmith.FlagsmithClientTest
                 isCalled = true;
                 return Task.CompletedTask;
             };
-            var x = new PollingManager(callback);
+            var x = new PollingManager(callback, TimeSpan.Zero);
             _ = x.StartPoll();
             Assert.True(isCalled);
             x.StopPoll();
@@ -32,7 +32,7 @@ namespace Flagsmith.FlagsmithClientTest
                 calledCount += 1;
                 return Task.CompletedTask;
             };
-            var x = new PollingManager(callback, 1);
+            var x = new PollingManager(callback, TimeSpan.FromSeconds(1));
             _ = x.StartPoll();
             await Task.Delay(3000);
             Assert.True(calledCount >= 3); // check pollingmanager polls atlease 3 times.

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -80,7 +80,7 @@ namespace Flagsmith
                         );
                     }
 
-                    _pollingManager = new PollingManager(GetAndUpdateEnvironmentFromApi, _config.EnvironmentRefreshIntervalSeconds);
+                    _pollingManager = new PollingManager(GetAndUpdateEnvironmentFromApi, _config.EnvironmentRefreshInterval);
                     Task.Run(async () => await _pollingManager.StartPoll()).GetAwaiter().GetResult();
                 }
             }
@@ -144,7 +144,7 @@ namespace Flagsmith
             {
                 EnvironmentKey = environmentKey,
                 ApiUri = new Uri(apiUrl),
-                EnvironmentRefreshIntervalSeconds = environmentRefreshIntervalSeconds,
+                EnvironmentRefreshInterval = TimeSpan.FromSeconds(environmentRefreshIntervalSeconds),
                 EnableLocalEvaluation = enableClientSideEvaluation,
                 Logger = logger,
                 EnableAnalytics = enableAnalytics,

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -92,7 +92,7 @@ namespace Flagsmith
                 _flagListCacheDictionary = new ConcurrentDictionary<string, IdentityFlagListCache>();
             }
         }
-        
+
         public FlagsmithClient(FlagsmithConfiguration configuration)
         {
             _config = configuration;

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -340,7 +340,7 @@ namespace Flagsmith
             try
             {
                 traits = traits ?? new List<ITrait>();
-                var url = new Uri(_config.ApiUri, "/identities/").AbsoluteUri;
+                var url = new Uri(_config.ApiUri, "identities/").AbsoluteUri;
                 var jsonBody = JsonConvert.SerializeObject(new { identifier = identity, traits, transient });
                 var jsonResponse = await GetJson(HttpMethod.Post, url, body: jsonBody).ConfigureAwait(false);
                 var flags = JsonConvert.DeserializeObject<Identity>(jsonResponse)?.flags?.ToList<IFlag>();

--- a/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
@@ -9,11 +9,10 @@ namespace Flagsmith
     public class FlagsmithConfiguration
     {
         private static readonly Uri DefaultApiUri = new Uri("https://edge.api.flagsmith.com/api/v1/");
-        private Uri _apiUri = DefaultApiUri;
         private TimeSpan _timeout;
         public FlagsmithConfiguration()
         {
-            ApiUrl = "https://edge.api.flagsmith.com/api/v1/";
+            ApiUri = DefaultApiUri;
             EnvironmentKey = string.Empty;
             EnvironmentRefreshIntervalSeconds = 60;
         }
@@ -25,8 +24,8 @@ namespace Flagsmith
         [Obsolete("Use ApiUri instead.")]
         public string ApiUrl
         {
-            get => _apiUri.ToString();
-            set => _apiUri = value.EndsWith("/") ? new Uri(value) : new Uri($"{value}/");
+            get => ApiUri.ToString();
+            set => ApiUri = value.EndsWith("/") ? new Uri(value) : new Uri($"{value}/");
         }
 
         /// <summary>
@@ -34,11 +33,7 @@ namespace Flagsmith
         /// <c>https://edge.api.flagsmith.com/api/v1/</c>.
         /// <example><code>new Uri("https://flagsmith.example.com/api/v1/")</code></example>
         /// </summary>
-        public Uri ApiUri
-        {
-            get => _apiUri;
-            set => _apiUri = value;
-        }
+        public Uri ApiUri { get; set; }
 
         /// <summary>
         /// The environment key obtained from Flagsmith interface.

--- a/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
@@ -6,7 +6,7 @@ using System.Net.Http;
 
 namespace Flagsmith
 {
-    public class FlagsmithConfiguration : IFlagsmithConfiguration
+    public class FlagsmithConfiguration
     {
         private static readonly Uri DefaultApiUri = new Uri("https://edge.api.flagsmith.com/api/v1/");
         private Uri _apiUri = DefaultApiUri;

--- a/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
@@ -10,12 +10,6 @@ namespace Flagsmith
     {
         private static readonly Uri DefaultApiUri = new Uri("https://edge.api.flagsmith.com/api/v1/");
         private TimeSpan _timeout;
-        public FlagsmithConfiguration()
-        {
-            ApiUri = DefaultApiUri;
-            EnvironmentKey = string.Empty;
-            EnvironmentRefreshIntervalSeconds = 60;
-        }
 
         /// <summary>
         /// <para>Override the URL of the Flagsmith API to communicate with.</para>
@@ -33,7 +27,7 @@ namespace Flagsmith
         /// <c>https://edge.api.flagsmith.com/api/v1/</c>.
         /// <example><code>new Uri("https://flagsmith.example.com/api/v1/")</code></example>
         /// </summary>
-        public Uri ApiUri { get; set; }
+        public Uri ApiUri { get; set; } = DefaultApiUri;
 
         /// <summary>
         /// The environment key obtained from Flagsmith interface.
@@ -54,6 +48,7 @@ namespace Flagsmith
         /// Enables local evaluation of flags.
         /// </summary>
         public bool EnableLocalEvaluation { get; set; }
+
         /// <summary>
         /// <para>If using local evaluation, specify the interval period between refreshes of local environment data.</para>
         /// <para>Deprecated since 7.1.0. Use <see cref="EnvironmentRefreshInterval"/> instead.</para>

--- a/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
@@ -1,29 +1,64 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using OfflineHandler;
+using System.Net.Http;
 
 namespace Flagsmith
 {
     public class FlagsmithConfiguration : IFlagsmithConfiguration
     {
+        private static readonly Uri DefaultApiUri = new Uri("https://edge.api.flagsmith.com/api/v1/");
+        private Uri _apiUri = DefaultApiUri;
+        private TimeSpan _timeout;
         public FlagsmithConfiguration()
         {
             ApiUrl = "https://edge.api.flagsmith.com/api/v1/";
             EnvironmentKey = string.Empty;
             EnvironmentRefreshIntervalSeconds = 60;
         }
+
         /// <summary>
-        /// Override the URL of the Flagsmith API to communicate with.
+        /// <para>Override the URL of the Flagsmith API to communicate with.</para>
+        /// <para>Deprecated since 7.1.0. Use <see cref="ApiUri"/> instead.</para>
         /// </summary>
-        public string ApiUrl { get; set; }
+        [Obsolete("Use ApiUri instead.")]
+        public string ApiUrl
+        {
+            get => _apiUri.ToString();
+            set => _apiUri = value.EndsWith("/") ? new Uri(value) : new Uri($"{value}/"); 
+        }
+
+        /// <summary>
+        /// Versioned base Flagsmith API URI to use for all requests. Defaults to
+        /// <c>https://edge.api.flagsmith.com/api/v1/</c>.
+        /// <example><code>new Uri("https://flagsmith.example.com/api/v1/")</code></example>
+        /// </summary>
+        public Uri ApiUri
+        {
+            get => _apiUri;
+            set => _apiUri = value;
+        }
+
         /// <summary>
         /// The environment key obtained from Flagsmith interface.
         /// </summary>
         public string EnvironmentKey { get; set; }
+
         /// <summary>
         /// Enables local evaluation of flags.
         /// </summary>
-        public bool EnableClientSideEvaluation { get; set; }
+        [Obsolete("Use EnableLocalEvaluation instead.")]
+        public bool EnableClientSideEvaluation
+        {
+            get => EnableLocalEvaluation;
+            set => EnableLocalEvaluation = value;
+        }
+
+        /// <summary>
+        /// Enables local evaluation of flags.
+        /// </summary>
+        public bool EnableLocalEvaluation { get; set; }
         /// <summary>
         /// If using local evaluation, specify the interval period between refreshes of local environment data.
         /// </summary>
@@ -31,7 +66,7 @@ namespace Flagsmith
         /// <summary>
         /// Callable which will be used in the case where flags cannot be retrieved from the API or a non existent feature is requested.
         /// </summary>
-        public Func<string, Flag> DefaultFlagHandler { get; set; }
+        public Func<string, Flag>? DefaultFlagHandler { get; set; }
         /// <summary>
         /// Provide logger for logging polling info & errors which is only applicable when client side evalution is enabled and analytics errors.
         /// </summary>
@@ -40,10 +75,24 @@ namespace Flagsmith
         /// if enabled, sends additional requests to the Flagsmith API to power flag analytics charts.
         /// </summary>
         public bool EnableAnalytics { get; set; }
+
         /// <summary>
         /// Number of seconds to wait for a request to complete before terminating the request
         /// </summary>
-        public Double? RequestTimeout { get; set; }
+        public Double? RequestTimeout
+        {
+            get => _timeout.Seconds;
+            set => _timeout = TimeSpan.FromSeconds(value ?? 100);
+        }
+
+        /// <summary>
+        /// Timeout duration to use for HTTP requests.
+        /// </summary>
+        public TimeSpan Timeout
+        {
+            get => _timeout;
+            set => _timeout = value;
+        }
         /// <summary>
         /// Total http retries for every failing request before throwing the final error.
         /// </summary>
@@ -56,7 +105,22 @@ namespace Flagsmith
         /// <summary>
         /// If enabled, the SDK will cache the flags for the duration specified in the CacheConfig
         /// </summary>
-        public CacheConfig CacheConfig { get; set; }
+        public CacheConfig CacheConfig { get; set; } = new CacheConfig(false);
+
+        /// <summary>
+        /// Indicates whether the client is in offline mode.
+        /// </summary>
+        public bool OfflineMode { get; set; }
+
+        /// <summary>
+        /// Handler for offline mode operations.
+        /// </summary>
+        public BaseOfflineHandler? OfflineHandler { get; set; }
+
+        /// <summary>
+        /// Http client used for flagsmith-API requests.
+        /// </summary>
+        public HttpClient HttpClient { get; set; } = new HttpClient();
 
         public bool IsValid()
         {

--- a/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
@@ -26,7 +26,7 @@ namespace Flagsmith
         public string ApiUrl
         {
             get => _apiUri.ToString();
-            set => _apiUri = value.EndsWith("/") ? new Uri(value) : new Uri($"{value}/"); 
+            set => _apiUri = value.EndsWith("/") ? new Uri(value) : new Uri($"{value}/");
         }
 
         /// <summary>

--- a/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
@@ -117,9 +117,10 @@ namespace Flagsmith
         /// </summary>
         public HttpClient HttpClient { get; set; } = new HttpClient();
 
+        [Obsolete("This method will be removed in a future release.")]
         public bool IsValid()
         {
-            return !string.IsNullOrEmpty(ApiUrl) && !string.IsNullOrEmpty(EnvironmentKey);
+            return !string.IsNullOrEmpty(ApiUri.ToString()) && !string.IsNullOrEmpty(EnvironmentKey);
         }
     }
 }

--- a/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
@@ -55,9 +55,19 @@ namespace Flagsmith
         /// </summary>
         public bool EnableLocalEvaluation { get; set; }
         /// <summary>
+        /// <para>If using local evaluation, specify the interval period between refreshes of local environment data.</para>
+        /// <para>Deprecated since 7.1.0. Use <see cref="EnvironmentRefreshInterval"/> instead.</para>
+        /// </summary>
+        [Obsolete("Use EnvironmentRefreshInterval instead.")]
+        public int EnvironmentRefreshIntervalSeconds
+        {
+            get => EnvironmentRefreshInterval.Seconds;
+            set => EnvironmentRefreshInterval = TimeSpan.FromSeconds(value);
+        }
+        /// <summary>
         /// If using local evaluation, specify the interval period between refreshes of local environment data.
         /// </summary>
-        public int EnvironmentRefreshIntervalSeconds { get; set; }
+        public TimeSpan EnvironmentRefreshInterval { get; set; } = TimeSpan.FromSeconds(60);
         /// <summary>
         /// Callable which will be used in the case where flags cannot be retrieved from the API or a non existent feature is requested.
         /// </summary>

--- a/Flagsmith.FlagsmithClient/IFlagsmithConfiguration.cs
+++ b/Flagsmith.FlagsmithClient/IFlagsmithConfiguration.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using OfflineHandler;
+using System.Net.Http;
 
 namespace Flagsmith
 {
+    [Obsolete("Use FlagsmithConfiguration instead.")]
     public interface IFlagsmithConfiguration
     {
         /// <summary>
@@ -60,6 +63,21 @@ namespace Flagsmith
         /// If enabled, the SDK will cache the flags for the duration specified in the CacheConfig
         /// </summary>
         CacheConfig CacheConfig { get; set; }
+
+        /// <summary>
+        /// Indicates whether the client is in offline mode.
+        /// </summary>
+        bool OfflineMode { get; set; }
+
+        /// <summary>
+        /// Handler for offline mode operations.
+        /// </summary>
+        BaseOfflineHandler OfflineHandler { get; set; }
+
+        /// <summary>
+        /// HTTP client used for Flagsmith API requests.
+        /// </summary>
+        HttpClient HttpClient { get; set; }
 
         bool IsValid();
     }

--- a/Flagsmith.FlagsmithClient/PollingManager.cs
+++ b/Flagsmith.FlagsmithClient/PollingManager.cs
@@ -23,7 +23,7 @@ namespace Flagsmith
             this._callback = callback;
             _interval = TimeSpan.FromSeconds(intervalSeconds);
         }
-        
+
         /// <param name="callback">Awaitable function that will be polled.</param>
         /// <param name="timespan">Polling interval.</param>
         public PollingManager(Func<Task> callback, TimeSpan timespan)


### PR DESCRIPTION
Fixes https://github.com/Flagsmith/flagsmith-dotnet-client/issues/135.

Validated this does not break existing code by running the existing test suite without changes: https://github.com/Flagsmith/flagsmith-dotnet-client/pull/136/commits/0b41d2b7edcf26ac218f369e399335717637830f
