### PR TITLE
Revert "fix!: throw exception on startup when using local evaluation without server key"

### DIFF
--- a/Flagsmith.Client.Test/Fixtures.cs
+++ b/Flagsmith.Client.Test/Fixtures.cs
@@ -8,7 +8,7 @@ namespace Flagsmith.FlagsmithClientTest
 {
     internal class Fixtures
     {
-        public static string ApiKey => "ser.test_key";
+        public static string ApiKey => "test_key";
         public static string ApiUrl => "http://test_url/";
         public static AnalyticsProcessorTest GetAnalyticalProcessorTest() => new(new HttpClient(), ApiKey, ApiUrl);
         public static JObject JsonObject = JObject.Parse(@"{

--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -524,24 +524,6 @@ namespace Flagsmith.FlagsmithClientTest
         }
 
         [Fact]
-        public void TestCannotCreateFlagsmithClientInLocalEvaluationWithoutServerAPIKey()
-        {
-            // When
-            Action createFlagsmith = () => new FlagsmithClient(
-                environmentKey: "foobar",
-                enableClientSideEvaluation: true
-            );
-
-            // Then
-            var exception = Assert.Throws<Exception>(() => createFlagsmith());
-            Assert.Equal
-            (
-                "ValueError: In order to use local evaluation, please generate a server key in the environment settings page.",
-                exception.Message
-            );
-        }
-
-        [Fact]
         /// <summary>
         /// Test that analytics data is consistent with concurrent calls to get flags.
         /// A huge number of threads are spawned to ensure that the issues related with
@@ -572,7 +554,7 @@ namespace Flagsmith.FlagsmithClientTest
                 featuresDictionary.TryAdd($"Feature_{i}", 0);
             }
 
-            // When
+            // When 
             var tasks = new Task[numberOfThreads];
 
             // Create numberOfThreads threads.
@@ -584,13 +566,13 @@ namespace Flagsmith.FlagsmithClientTest
                 // Prepare an array of feature names of length callsPerThread.
                 for (int j = 0; j < callsPerThread; j++)
                 {
-                    // The feature names are randomly selected from the featuresDictionary and added to the
-                    // list of features, which represents the features that have been evaluated.
+                    // The feature names are randomly selected from the featuresDictionary and added to the 
+                    // list of features, which represents the features that have been evaluated.  
                     string featureName = $"Feature_{new Random().Next(1, featuresDictionary.Count + 1)}";
                     features[j] = featureName;
 
                     // The relevant key in the featuresDictionary is incremented to simulate an evaluation
-                    // to track for that feature.
+                    // to track for that feature. 
                     featuresDictionary[featureName]++;
                 }
 

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -150,8 +150,8 @@ namespace Flagsmith
                 {
                     if (!EnvironmentKey!.StartsWith("ser."))
                     {
-                        throw new Exception(
-                            "ValueError: In order to use local evaluation, please generate a server key in the environment settings page."
+                        Console.WriteLine(
+                            "In order to use local evaluation, please generate a server key in the environment settings page."
                         );
                     }
 


### PR DESCRIPTION
Reverts Flagsmith/flagsmith-dotnet-client#141

Reverting so that we can first merge this PR, release a 7.1.0, then create an 8.0.0 version which adds this breaking change back, and removes the methods marked for deprecation in #136 . 