### PR TITLE
chore: Partial revert - remove TimeSpan Timeout option

### DIFF
--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -284,7 +284,7 @@ namespace Flagsmith
                         request.Content = new StringContent(body, Encoding.UTF8, "application/json");
                     }
 
-                    var cancellationTokenSource = new CancellationTokenSource(_config.Timeout);
+                    var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(_config.RequestTimeout ?? 100));
                     HttpResponseMessage response = await _config.HttpClient.SendAsync(request, cancellationTokenSource.Token).ConfigureAwait(false);
                     return response.EnsureSuccessStatusCode();
                 }).ConfigureAwait(false)).Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
@@ -86,14 +86,6 @@ namespace Flagsmith
         }
 
         /// <summary>
-        /// Timeout duration to use for HTTP requests.
-        /// </summary>
-        public TimeSpan Timeout
-        {
-            get => _timeout;
-            set => _timeout = value;
-        }
-        /// <summary>
         /// Total http retries for every failing request before throwing the final error.
         /// </summary>
         public int? Retries { get; set; }


### PR DESCRIPTION
In https://github.com/Flagsmith/flagsmith-dotnet-client/pull/136, I added the `TimeSpan Timeout` option, with the goal of eventually replacing `Double? RequestTimeout`. The goal is to accept a `TimeSpan` and not a number which we then convert to seconds - this is a best practice in .NET and really everywhere I'd say.

After reviewing this in more detail, I decided I don't like the name `Timeout` because it's vague. I'd really like to keep the name `RequestTimeout`, but we can't change it to `TimeSpan RequestTimeout` without making a breaking change.

Instead of deprecating `RequestTimeout`, I'd prefer to change its type to `TimeSpan` in 8.x directly. I realise we're not giving advance notice of this breaking change, but at least it's a trivial change:

```
// before
RequestTimeout = 10

// after
RequestTimeout = TimeSpan.FromSeconds(10)
```

I only noticed this issue when updating the docs for 7.1.0, which is not yet released.