### PR TITLE
fix: RequestTimeout would return the seconds component of its TimeSpan instead of the total duration in seconds

### DIFF
--- a/Flagsmith.Client.Test/FlagsmithTest.cs
+++ b/Flagsmith.Client.Test/FlagsmithTest.cs
@@ -802,5 +802,15 @@ namespace Flagsmith.FlagsmithClientTest
             Assert.True(await identityFlags.IsFeatureEnabled("some_feature"));
             Assert.Equal("some-identity-trait-value", await identityFlags.GetFeatureValue("some_feature"));
         }
+
+        [Fact]
+        public void TestRequestTimeoutInterpretsSecondsCorrectly()
+        {
+            var config = new FlagsmithConfiguration
+            {
+                RequestTimeout = 100
+            };
+            Assert.Equal(100, config.RequestTimeout);
+        }
     }
 }

--- a/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
@@ -81,7 +81,7 @@ namespace Flagsmith
         /// </summary>
         public Double? RequestTimeout
         {
-            get => _timeout.Seconds;
+            get => _timeout.TotalSeconds;
             set => _timeout = TimeSpan.FromSeconds(value ?? 100);
         }
 


### PR DESCRIPTION
Fixes https://github.com/Flagsmith/flagsmith-dotnet-client/issues/148.