### PR TITLE
chore: update PackageLicenseExpression to conforming SPDK identifier

### DIFF
--- a/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj
+++ b/Flagsmith.FlagsmithClient/Flagsmith.FlagsmithClient.csproj
@@ -18,7 +18,7 @@
         <PackageTags>feature flags remote config toggles</PackageTags>
         <RepositoryUrl>https://github.com/Flagsmith/flagsmith-dotnet-client</RepositoryUrl>
         <NeutralLanguage>en-GB</NeutralLanguage>
-        <PackageLicenseExpression>BSD-3</PackageLicenseExpression>
+        <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Resolve issue introduced in #158 by updating to the correct SPDX identifier. 