### PR TITLE
fix(Engine): Fix segment condition evaluation across all system locales

### DIFF
--- a/Flagsmith.Engine/Segment/Evaluator.cs
+++ b/Flagsmith.Engine/Segment/Evaluator.cs
@@ -8,7 +8,6 @@ using Newtonsoft.Json.Linq;
 using Semver;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 
 namespace FlagsmithEngine.Segment
@@ -374,7 +373,7 @@ namespace FlagsmithEngine.Segment
             long conditionValue;
             try
             {
-                conditionValue = Convert.ToInt64(condition.Value, CultureInfo.InvariantCulture);
+                conditionValue = InvariantConvert.ToInt64(condition.Value);
             }
             catch (FormatException)
             {
@@ -397,12 +396,12 @@ namespace FlagsmithEngine.Segment
         {
             switch (condition.Operator)
             {
-                case Constants.Equal: return traitValue == Convert.ToInt32(condition.Value, CultureInfo.InvariantCulture);
-                case Constants.NotEqual: return traitValue != Convert.ToInt32(condition.Value, CultureInfo.InvariantCulture);
-                case Constants.GreaterThan: return traitValue > Convert.ToInt32(condition.Value, CultureInfo.InvariantCulture);
-                case Constants.GreaterThanInclusive: return traitValue >= Convert.ToInt32(condition.Value, CultureInfo.InvariantCulture);
-                case Constants.LessThan: return traitValue < Convert.ToInt32(condition.Value, CultureInfo.InvariantCulture);
-                case Constants.LessThanInclusive: return traitValue <= Convert.ToInt32(condition.Value, CultureInfo.InvariantCulture);
+                case Constants.Equal: return traitValue == InvariantConvert.ToInt32(condition.Value);
+                case Constants.NotEqual: return traitValue != InvariantConvert.ToInt32(condition.Value);
+                case Constants.GreaterThan: return traitValue > InvariantConvert.ToInt32(condition.Value);
+                case Constants.GreaterThanInclusive: return traitValue >= InvariantConvert.ToInt32(condition.Value);
+                case Constants.LessThan: return traitValue < InvariantConvert.ToInt32(condition.Value);
+                case Constants.LessThanInclusive: return traitValue <= InvariantConvert.ToInt32(condition.Value);
                 case Constants.In: return condition.Value.Split(',').Contains(traitValue.ToString());
                 default: throw new ArgumentException("Invalid Operator");
             }
@@ -412,12 +411,12 @@ namespace FlagsmithEngine.Segment
         {
             switch (condition.Operator)
             {
-                case Constants.Equal: return traitValue == Convert.ToDouble(condition.Value, CultureInfo.InvariantCulture);
-                case Constants.NotEqual: return traitValue != Convert.ToDouble(condition.Value, CultureInfo.InvariantCulture);
-                case Constants.GreaterThan: return traitValue > Convert.ToDouble(condition.Value, CultureInfo.InvariantCulture);
-                case Constants.GreaterThanInclusive: return traitValue >= Convert.ToDouble(condition.Value, CultureInfo.InvariantCulture);
-                case Constants.LessThan: return traitValue < Convert.ToDouble(condition.Value, CultureInfo.InvariantCulture);
-                case Constants.LessThanInclusive: return traitValue <= Convert.ToDouble(condition.Value, CultureInfo.InvariantCulture);
+                case Constants.Equal: return traitValue == InvariantConvert.ToDouble(condition.Value);
+                case Constants.NotEqual: return traitValue != InvariantConvert.ToDouble(condition.Value);
+                case Constants.GreaterThan: return traitValue > InvariantConvert.ToDouble(condition.Value);
+                case Constants.GreaterThanInclusive: return traitValue >= InvariantConvert.ToDouble(condition.Value);
+                case Constants.LessThan: return traitValue < InvariantConvert.ToDouble(condition.Value);
+                case Constants.LessThanInclusive: return traitValue <= InvariantConvert.ToDouble(condition.Value);
                 case Constants.In: return false;
                 default: throw new ArgumentException("Invalid Operator");
             }

--- a/Flagsmith.Engine/Segment/Evaluator.cs
+++ b/Flagsmith.Engine/Segment/Evaluator.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using Semver;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace FlagsmithEngine.Segment
@@ -373,7 +374,7 @@ namespace FlagsmithEngine.Segment
             long conditionValue;
             try
             {
-                conditionValue = Convert.ToInt64(condition.Value);
+                conditionValue = Convert.ToInt64(condition.Value, CultureInfo.InvariantCulture);
             }
             catch (FormatException)
             {
@@ -396,12 +397,12 @@ namespace FlagsmithEngine.Segment
         {
             switch (condition.Operator)
             {
-                case Constants.Equal: return traitValue == Convert.ToInt32(condition.Value);
-                case Constants.NotEqual: return traitValue != Convert.ToInt32(condition.Value);
-                case Constants.GreaterThan: return traitValue > Convert.ToInt32(condition.Value);
-                case Constants.GreaterThanInclusive: return traitValue >= Convert.ToInt32(condition.Value);
-                case Constants.LessThan: return traitValue < Convert.ToInt32(condition.Value);
-                case Constants.LessThanInclusive: return traitValue <= Convert.ToInt32(condition.Value);
+                case Constants.Equal: return traitValue == Convert.ToInt32(condition.Value, CultureInfo.InvariantCulture);
+                case Constants.NotEqual: return traitValue != Convert.ToInt32(condition.Value, CultureInfo.InvariantCulture);
+                case Constants.GreaterThan: return traitValue > Convert.ToInt32(condition.Value, CultureInfo.InvariantCulture);
+                case Constants.GreaterThanInclusive: return traitValue >= Convert.ToInt32(condition.Value, CultureInfo.InvariantCulture);
+                case Constants.LessThan: return traitValue < Convert.ToInt32(condition.Value, CultureInfo.InvariantCulture);
+                case Constants.LessThanInclusive: return traitValue <= Convert.ToInt32(condition.Value, CultureInfo.InvariantCulture);
                 case Constants.In: return condition.Value.Split(',').Contains(traitValue.ToString());
                 default: throw new ArgumentException("Invalid Operator");
             }
@@ -411,12 +412,12 @@ namespace FlagsmithEngine.Segment
         {
             switch (condition.Operator)
             {
-                case Constants.Equal: return traitValue == Convert.ToDouble(condition.Value);
-                case Constants.NotEqual: return traitValue != Convert.ToDouble(condition.Value);
-                case Constants.GreaterThan: return traitValue > Convert.ToDouble(condition.Value);
-                case Constants.GreaterThanInclusive: return traitValue >= Convert.ToDouble(condition.Value);
-                case Constants.LessThan: return traitValue < Convert.ToDouble(condition.Value);
-                case Constants.LessThanInclusive: return traitValue <= Convert.ToDouble(condition.Value);
+                case Constants.Equal: return traitValue == Convert.ToDouble(condition.Value, CultureInfo.InvariantCulture);
+                case Constants.NotEqual: return traitValue != Convert.ToDouble(condition.Value, CultureInfo.InvariantCulture);
+                case Constants.GreaterThan: return traitValue > Convert.ToDouble(condition.Value, CultureInfo.InvariantCulture);
+                case Constants.GreaterThanInclusive: return traitValue >= Convert.ToDouble(condition.Value, CultureInfo.InvariantCulture);
+                case Constants.LessThan: return traitValue < Convert.ToDouble(condition.Value, CultureInfo.InvariantCulture);
+                case Constants.LessThanInclusive: return traitValue <= Convert.ToDouble(condition.Value, CultureInfo.InvariantCulture);
                 case Constants.In: return false;
                 default: throw new ArgumentException("Invalid Operator");
             }

--- a/Flagsmith.Engine/Segment/Evaluator.cs
+++ b/Flagsmith.Engine/Segment/Evaluator.cs
@@ -250,7 +250,7 @@ namespace FlagsmithEngine.Segment
                             Enabled = featureContext.Enabled,
                             Value = variant.Value,
                             Metadata = featureContext.Metadata,
-                            Reason = $"SPLIT; weight={weight}",
+                            Reason = FormattableString.Invariant($"SPLIT; weight={weight}"),
                         };
                         break;
                     }

--- a/Flagsmith.Engine/Segment/Models/SegmentConditionModel.cs
+++ b/Flagsmith.Engine/Segment/Models/SegmentConditionModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 using System;
+using System.Globalization;
 using Newtonsoft.Json;
 namespace FlagsmithEngine.Segment.Models
 {
@@ -21,10 +22,10 @@ namespace FlagsmithEngine.Segment.Models
                 string[] parts = this.Value.Split('|');
                 if (parts.Length != 2) { return false; }
 
-                double divisor = Convert.ToDouble(parts[0]);
-                double remainder = Convert.ToDouble(parts[1]);
+                double divisor = Convert.ToDouble(parts[0], CultureInfo.InvariantCulture);
+                double remainder = Convert.ToDouble(parts[1], CultureInfo.InvariantCulture);
 
-                return Convert.ToDouble(traitValue) % divisor == remainder;
+                return Convert.ToDouble(traitValue, CultureInfo.InvariantCulture) % divisor == remainder;
             }
             catch (FormatException)
             {

--- a/Flagsmith.Engine/Utils/InvariantConvert.cs
+++ b/Flagsmith.Engine/Utils/InvariantConvert.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Globalization;
+
+namespace FlagsmithEngine.Utils
+{
+    /// <summary>
+    /// Provides culture-invariant conversion methods for numeric types.
+    /// </summary>
+    /// <remarks>
+    /// Ensures consistent numeric parsing across all system locales by using InvariantCulture.
+    /// Prevents locale-specific decimal separator issues (e.g., "1.23" vs "1,23").
+    /// </remarks>
+    internal static class InvariantConvert
+    {
+        /// <summary>
+        /// Converts the string representation of a number to its 32-bit signed integer equivalent
+        /// using culture-invariant formatting.
+        /// </summary>
+        /// <param name="value">A string containing a number to convert.</param>
+        /// <returns>A 32-bit signed integer equivalent to the number in value.</returns>
+        public static int ToInt32(string value) =>
+            Convert.ToInt32(value, CultureInfo.InvariantCulture);
+
+        /// <summary>
+        /// Converts the string representation of a number to its 64-bit signed integer equivalent
+        /// using culture-invariant formatting.
+        /// </summary>
+        /// <param name="value">A string containing a number to convert.</param>
+        /// <returns>A 64-bit signed integer equivalent to the number in value.</returns>
+        public static long ToInt64(string value) =>
+            Convert.ToInt64(value, CultureInfo.InvariantCulture);
+
+        /// <summary>
+        /// Converts the string representation of a number to its double-precision floating-point equivalent
+        /// using culture-invariant formatting.
+        /// </summary>
+        /// <param name="value">A string containing a number to convert.</param>
+        /// <returns>A double-precision floating-point number equivalent to the numeric value in value.</returns>
+        public static double ToDouble(string value) =>
+            Convert.ToDouble(value, CultureInfo.InvariantCulture);
+    }
+}

--- a/Flagsmith.EngineTest/Unit/Traits/TraitSchemaTest.cs
+++ b/Flagsmith.EngineTest/Unit/Traits/TraitSchemaTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using Xunit;
 using Newtonsoft.Json.Linq;
@@ -30,7 +31,7 @@ namespace EngineTest.Unit.Traits
             var jObject = JObject.FromObject(trait);
             Assert.Equal(trait.TraitKey, jObject["trait_key"].Value<string>());
             var valueToken = jObject["trait_value"];
-            var value = valueToken.Type != JTokenType.Null ? Convert.ChangeType(valueToken.Value<string>(), trait.TraitValue.GetType()) : null;
+            var value = valueToken.Type != JTokenType.Null ? Convert.ChangeType(valueToken.Value<string>(), trait.TraitValue.GetType(), CultureInfo.InvariantCulture) : null;
             Assert.Equal(trait.TraitValue, value);
         }
         public static IEnumerable<object[]> TestTraitToJobjectData() =>


### PR DESCRIPTION
Fix segment condition evaluation across all system locales.

## Changes
- Apply locale-independent parsing to numeric strings in segment conditions

## How to reproduce

```bash
LANG=de_DE.UTF-8 LC_ALL=de_DE.UTF-8 dotnet test
```

## Test failure example

```
Failed: EngineTest.Unit.Segments.SegmentEvaluatorTest.TestSegmentConditionMatchesTraitValue(
  _operator: "EQUAL", 
  traitValue: 1,23, 
  conditionValue: "1.23", 
  expectedResult: True
)
Expected: True
Actual:   False
```

> [!NOTE]
> CI uses C.UTF-8 locale (period decimal separator). This bug could affect German, French, Spanish, Italian, Portuguese, and other locales using comma as decimal separator.

Review effort: 1/5