### PR TITLE
fix: Exclude identities when PERCENTAGE_SPLIT trait is undefined

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Flagsmith.EngineTest/EngineTestData"]
 	path = Flagsmith.EngineTest/EngineTestData
 	url = git@github.com:Flagsmith/engine-test-data.git
-	tag = v3.4.2
+	tag = v3.5.0

--- a/Flagsmith.Engine/Engine.cs
+++ b/Flagsmith.Engine/Engine.cs
@@ -203,7 +203,7 @@ namespace FlagsmithEngine
 
                     if (contextValue != null)
                         objectIds = new List<string> { segmentKey, contextValue.ToString() };
-                    else if (context.Identity?.Key != null)
+                    else if (string.IsNullOrEmpty(condition.Property) && context.Identity?.Key != null)
                         objectIds = new List<string> { segmentKey, context.Identity.Key };
                     else
                         return false;

--- a/Flagsmith.EngineTest/EngineTest.cs
+++ b/Flagsmith.EngineTest/EngineTest.cs
@@ -49,7 +49,7 @@ namespace EngineTest
             var result = _iengine.GetEvaluationResult(testCase.Context);
 
             // Then
-            Assert.Equivalent(testCase.Result, result);
+            Assert.Equivalent(testCase.Result, result, strict: true);
         }
 
         public static IEnumerable<object[]> ExtractTestCaseFilenames()


### PR DESCRIPTION
Closes #178.