### PR TITLE
fix(CI): Run CI tests against the expected .NET version

### DIFF
--- a/.github/workflows/formatting-and-tests.yml
+++ b/.github/workflows/formatting-and-tests.yml
@@ -39,7 +39,7 @@ jobs:
             max-parallel: 4
             matrix:
                 working-directory: ["Flagsmith.EngineTest","Flagsmith.Client.Test"]
-                dotnet-version: ["6.x", "7.x", "8.x", "9.x", "10.x"]
+                dotnet-version: ["6.0", "7.0", "8.0", "9.0", "10.0"]
 
         steps:
           - name: Cloning repo
@@ -52,17 +52,10 @@ jobs:
             run: make clone-engine-test-data
 
           - name: Set up Dotnet ${{ matrix.dotnet-version }}
-            uses: actions/setup-dotnet@v3
+            uses: actions/setup-dotnet@v4
             with:
-                dotnet-version: |
-                  6.0.x
-                  ${{ matrix.dotnet-version }}
+                dotnet-version: ${{ matrix.dotnet-version }}.x
 
           - name: Run Tests
-            # bafflingly adding the below debugging echo / version statements got the workflow to pass
-            run: |
-              echo "Dotnet version: "
-              dotnet --version
-              echo "-------"
-              dotnet test
+            run: dotnet test --framework net${{ matrix.dotnet-version }}
             working-directory: ${{ matrix.working-directory }}

--- a/Flagsmith.Client.Test/ClientTest.csproj
+++ b/Flagsmith.Client.Test/ClientTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Flagsmith.EngineTest/EngineTest.csproj
+++ b/Flagsmith.EngineTest/EngineTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
Fix CI so it actually runs tests against the expected .NET framework version.

Closes #176 