### PR TITLE
ci: Use NuGet trusted publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,33 +19,33 @@ jobs:
   create_nuget:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    # Install the .NET SDK indicated in the global.json file
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+      # Install the .NET SDK indicated in the global.json file
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
 
-    # Create the NuGet package in the folder from the environment variable NuGetDirectory
-    - run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }}
+      # Create the NuGet package in the folder from the environment variable NuGetDirectory
+      - run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }}
 
-    # Publish the NuGet package as an artifact, so they can be used in the following jobs
-    - uses: actions/upload-artifact@v4
-      with:
-        name: nuget
-        if-no-files-found: error
-        retention-days: 7
-        path: |
+      # Publish the NuGet package as an artifact, so they can be used in the following jobs
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nuget
+          if-no-files-found: error
+          retention-days: 7
+          path: |
             ${{ env.NuGetDirectory }}/Flagsmith.*.nupkg
             !${{ env.NuGetDirectory }}/Flagsmith.Engine*
 
   validate_nuget:
     runs-on: ubuntu-latest
     needs:
-        - create_nuget
+      - create_nuget
     steps:
       # Install the .NET SDK indicated in the global.json file
       - name: Setup .NET
@@ -66,13 +66,17 @@ jobs:
       # https://www.nuget.org/packages/Meziantou.Framework.NuGetPackageValidation.Tool#readme-body-tab
       # TODO https://github.com/Flagsmith/flagsmith-dotnet-client/issues/96
       - name: Validate package
-        run: meziantou.validate-nuget-package (Get-ChildItem "${{ env.NuGetDirectory }}/*.nupkg") --excluded-rule-ids 101,111,74,72,61,12
+        run: meziantou.validate-nuget-package (Get-ChildItem "${{ env.NuGetDirectory
+          }}/*.nupkg") --excluded-rule-ids 101,111,74,72,61,12
 
   publish:
     runs-on: ubuntu-latest
     needs:
-        - create_nuget
-        - validate_nuget
+      - create_nuget
+      - validate_nuget
+    permissions:
+      id-token: write # required for NuGet trusted publishing (OIDC)
+      contents: read
     steps:
       # Download the NuGet package created in the previous job
       - uses: actions/download-artifact@v4
@@ -86,11 +90,19 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      # Exchange the GitHub OIDC token for a short-lived NuGet.org API key.
+      # Requires a Trusted Publishing policy configured on nuget.org for this repo + workflow file.
+      - name: NuGet login (OIDC -> temp API key)
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ vars.NUGET_USER }}
+
       # Publish all NuGet packages to NuGet.org
       - name: Publish NuGet package
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
-              dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json
+              dotnet nuget push $file --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json
           }
 
       - name: Upload Release Asset


### PR DESCRIPTION
In this PR, we add Nuget trusted publishing.

## Prerequisites (done out-of-band)
- Trusted Publishing policy created on nuget.org: owner `Flagsmith`, repo `flagsmith-dotnet-client`, workflow `release.yml`, no environment.
- `Flagsmith` org added as co-owner of all `Flagsmith.*` packages published by this workflow.
- Repo variable `NUGET_USER` set.

## Test plan
- [x] Merge PR.
- [ ] On the next release-please release merge, confirm the `Publish Release` workflow's `NuGet login (OIDC -> temp API key)` step succeeds and masks the output.
- [ ] Confirm `dotnet nuget push` succeeds for all `Flagsmith.*.nupkg` (excluding `Flagsmith.Engine*` per existing artifact filter).
- [ ] After first successful publish, revoke the old `NUGET_APIKEY` on nuget.org and delete the GitHub secret.

## Rollback
Restore `NUGET_APIKEY` secret and revert this PR — one-minute operation.