### PR TITLE
ci: setup Renovate for engine-test-data tracking

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Flagsmith.EngineTest/EngineTestData"]
 	path = Flagsmith.EngineTest/EngineTestData
 	url = git@github.com:Flagsmith/engine-test-data.git
-	tag = v3.5.0
+	branch = v3.5.0

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended", ":semanticCommitScopeDisabled"],
+    "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
+    "semanticCommitType": "deps",
+    "git-submodules": { "enabled": true },
+    "packageRules": [
+        {
+            "matchUpdateTypes": [
+                "major",
+                "minor",
+                "patch",
+                "digest",
+                "pin",
+                "rollback",
+                "bump",
+                "replacement",
+                "lockFileMaintenance"
+            ],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["git-submodules"],
+            "enabled": true
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Adds Renovate configuration to automatically track `engine-test-data` submodule updates and security vulnerabilities.

Also fixes `.gitmodules` to use `branch` instead of `tag` — Renovate's git-submodules manager reads the `branch` field to detect version updates.

| Rule | Effect |
|---|---|
| `extends: config:recommended` | Renovate defaults (Dependency Dashboard, etc.) |
| Disable all routine updates | All `matchUpdateTypes` except `vulnerabilityAlerts` → blocked |
| Enable git-submodules | Tracks `engine-test-data` releases and opens PRs |
| **CVE / security alerts** | Pass through (not in disabled list) |
| `.gitmodules` fix | `tag` → `branch` for Renovate compatibility |

**Net effect**: only two things trigger PRs — a new `engine-test-data` release, or a CVE on any dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)