### PR TITLE
fix: respect rule type for sub-rules in segment evaluation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Flagsmith.EngineTest/EngineTestData"]
 	path = Flagsmith.EngineTest/EngineTestData
 	url = git@github.com:Flagsmith/engine-test-data.git
-	branch = v3.5.0
+	branch = v3.7.0

--- a/Flagsmith.Engine/Engine.cs
+++ b/Flagsmith.Engine/Engine.cs
@@ -168,7 +168,29 @@ namespace FlagsmithEngine
                         break;
                 }
 
-            return matchesConditions && (rule.Rules?.All(r => ContextMatchesRule(context, r, segmentKey)) ?? true);
+            if (!matchesConditions)
+                return false;
+
+            if (rule.Rules is null || !rule.Rules.Any())
+                return true;
+
+            bool matchesSubRules;
+            switch (rule.Type)
+            {
+                case TypeEnum.All:
+                    matchesSubRules = rule.Rules.All(r => ContextMatchesRule(context, r, segmentKey));
+                    break;
+                case TypeEnum.Any:
+                    matchesSubRules = rule.Rules.Any(r => ContextMatchesRule(context, r, segmentKey));
+                    break;
+                case TypeEnum.None:
+                    matchesSubRules = !rule.Rules.Any(r => ContextMatchesRule(context, r, segmentKey));
+                    break;
+                default:
+                    matchesSubRules = false;
+                    break;
+            }
+            return matchesSubRules;
         }
 
         private static bool ContextMatchesCondition<_, __>(EvaluationContext<_, __> context, Condition condition, string segmentKey)


### PR DESCRIPTION
## Summary
- Bumped engine-test-data submodule from v3.5.0 to v3.7.0
- Fixed segment evaluation: sub-rules now respect the parent rule's type (ANY/ALL/NONE) instead of hardcoding ALL

Equivalent fix to [flagsmith-engine#313](https://github.com/Flagsmith/flagsmith-engine/pull/313).

## Test plan
- [x] Bumped engine-test-data to v3.7.0 (includes 3 new sub-rule type test cases)
- [x] Applied the fix
- [ ] Verify all tests pass in CI (dotnet SDK not available locally)