### PR TITLE
feat: Allow configuring analytics API endpoint separate from flags API

### DIFF
--- a/Flagsmith.Client.Test/AnalyticsProcessorTest.cs
+++ b/Flagsmith.Client.Test/AnalyticsProcessorTest.cs
@@ -13,8 +13,8 @@ namespace Flagsmith.FlagsmithClientTest
         /// <summary>
         /// This class provides some extra functionality to help particularly in unit testing.
         /// </summary>
-        public AnalyticsProcessorTest(HttpClient httpClient, string environmentKey, string baseApiUrl, int timeOut = 3)
-            : base(httpClient, environmentKey, baseApiUrl, timeOut: timeOut)
+        public AnalyticsProcessorTest(HttpClient httpClient, string environmentKey, Uri analyticsUri, int timeOut = 3)
+            : base(httpClient, environmentKey, analyticsUri, timeOut: timeOut)
         {
         }
         /// <summary>

--- a/Flagsmith.Client.Test/AnalyticsTests.cs
+++ b/Flagsmith.Client.Test/AnalyticsTests.cs
@@ -14,7 +14,8 @@ namespace Flagsmith.FlagsmithClientTest
 {
     public class AnalyticsTests
     {
-        const string _defaultApiUrl = "https://edge.api.flagsmith.com/api/v1/";
+        static readonly Uri _defaultApiUri = new Uri("https://edge.api.flagsmith.com/api/v1/");
+        static readonly Uri _defaultAnalyticsUri = new Uri(_defaultApiUri, "analytics/flags/");
 
         [Fact]
         public async Task TestAnalyticsProcessorDoesNotThrowUnderLoad()
@@ -27,7 +28,7 @@ namespace Flagsmith.FlagsmithClientTest
             HttpMocker.PayloadsSubmitted = new System.Collections.Concurrent.ConcurrentBag<string>();
 
             var mockHttpClient = HttpMocker.MockHttpResponse(System.Net.HttpStatusCode.OK, null, true);
-            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, null);
+            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, _defaultAnalyticsUri);
             var token = new CancellationToken();
             await Parallel.ForEachAsync(Enumerable.Range(1, numberOfThreads), token, async (item, token) =>
             {
@@ -69,7 +70,7 @@ namespace Flagsmith.FlagsmithClientTest
             {
                 StatusCode = System.Net.HttpStatusCode.OK,
             });
-            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, null);
+            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, _defaultAnalyticsUri);
             await analyticsProcessor.TrackFeature("TestAnalyticsProcessorFlushClearsAnalyticsDataFeature");
             await analyticsProcessor.Flush();
             Assert.False(analyticsProcessor.HasTrackingItemsInCache());
@@ -81,7 +82,7 @@ namespace Flagsmith.FlagsmithClientTest
             {
                 StatusCode = System.Net.HttpStatusCode.OK,
             });
-            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, baseApiUrl: _defaultApiUrl);
+            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, analyticsUri: _defaultAnalyticsUri);
             await analyticsProcessor.TrackFeature("TestAnalyticsProcessorFlushPostRequestDataMatchAnanlyticsDataFeature1");
             await analyticsProcessor.TrackFeature("TestAnalyticsProcessorFlushPostRequestDataMatchAnanlyticsDataFeature2");
             var jObject = JObject.Parse(analyticsProcessor.ToString());
@@ -91,13 +92,77 @@ namespace Flagsmith.FlagsmithClientTest
             Assert.Equal(1, jObject["TestAnalyticsProcessorFlushPostRequestDataMatchAnanlyticsDataFeature2"].Value<int>());
         }
         [Fact]
+        public async Task TestAnalyticsProcessorPostsToConfiguredAnalyticsUri()
+        {
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+            });
+            var analyticsUri = new Uri("https://analytics.example.com/api/v1/analytics/flags/");
+            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, Fixtures.ApiKey, analyticsUri);
+            await analyticsProcessor.TrackFeature("some_feature");
+            await analyticsProcessor.Flush();
+            mockHttpClient.Verify(x => x.SendAsync(
+                It.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Post && req.RequestUri == analyticsUri),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+        [Fact]
+        public async Task TestAnalyticsProcessorBaseApiUrlConstructorPostsToAnalyticsEndpoint()
+        {
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+            });
+            var analyticsProcessor = new AnalyticsProcessor(mockHttpClient.Object, Fixtures.ApiKey, _defaultApiUri.ToString());
+            await analyticsProcessor.TrackFeature("some_feature");
+            await analyticsProcessor.Flush();
+            VerifyAnalyticsPostedTo(mockHttpClient, _defaultAnalyticsUri);
+        }
+        [Fact]
+        public async Task TestFlagsmithClientPostsAnalyticsToExpectedUri()
+        {
+            var customAnalyticsUri = new Uri("https://analytics.example.com/api/v1/analytics/flags/");
+            // A client using the default analytics endpoint, relative to the API URI...
+            var (defaultUriMock, defaultUriFlags) = await GetClientFlags(analyticsUri: null);
+            // ...and a client with an analytics endpoint configured separately from the API URI
+            var (customUriMock, customUriFlags) = await GetClientFlags(customAnalyticsUri);
+            await Task.Delay(11 * 1000);
+            await defaultUriFlags.IsFeatureEnabled("some_feature");
+            await customUriFlags.IsFeatureEnabled("some_feature");
+            // Tracking a feature does not await the flush it triggers, so give the requests time to be made
+            await Task.Delay(2 * 1000);
+            VerifyAnalyticsPostedTo(defaultUriMock, _defaultAnalyticsUri);
+            VerifyAnalyticsPostedTo(customUriMock, customAnalyticsUri);
+        }
+        private static async Task<(Mock<HttpClient>, IFlags)> GetClientFlags(Uri analyticsUri)
+        {
+            var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(Fixtures.ApiFlagResponse)
+            });
+            var client = new FlagsmithClient(new FlagsmithConfiguration
+            {
+                EnvironmentKey = Fixtures.ApiKey,
+                ApiUri = _defaultApiUri,
+                AnalyticsUri = analyticsUri,
+                HttpClient = mockHttpClient.Object,
+                EnableAnalytics = true
+            });
+            return (mockHttpClient, await client.GetEnvironmentFlags());
+        }
+        private static void VerifyAnalyticsPostedTo(Mock<HttpClient> mockHttpClient, Uri expectedUri)
+            => mockHttpClient.Verify(x => x.SendAsync(
+                It.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Post && req.RequestUri == expectedUri),
+                It.IsAny<CancellationToken>()), Times.Once);
+        [Fact]
         public async Task TestAnalyticsProcessorFlushEarlyExitIfAnalyticsDataIsEmpty()
         {
             var mockHttpClient = HttpMocker.MockHttpResponse(new HttpResponseMessage
             {
                 StatusCode = System.Net.HttpStatusCode.OK,
             });
-            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, baseApiUrl: _defaultApiUrl);
+            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, analyticsUri: _defaultAnalyticsUri);
             await analyticsProcessor.Flush();
             mockHttpClient.Verify(x => x.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()), Times.Never);
         }
@@ -108,7 +173,7 @@ namespace Flagsmith.FlagsmithClientTest
             {
                 StatusCode = System.Net.HttpStatusCode.OK,
             });
-            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, baseApiUrl: _defaultApiUrl);
+            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, analyticsUri: _defaultAnalyticsUri);
             await Task.Delay(12 * 1000);
             await analyticsProcessor.TrackFeature("TestAnalyticsProcessorCallingTrackFeatureCallsFlushWhenTimerRunsOutFeature");
             mockHttpClient.VerifyHttpRequest(HttpMethod.Post, "/api/v1/analytics/flags/", Times.Once);
@@ -122,7 +187,7 @@ namespace Flagsmith.FlagsmithClientTest
             {
                 StatusCode = System.Net.HttpStatusCode.OK,
             });
-            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, null);
+            var analyticsProcessor = new AnalyticsProcessorTest(mockHttpClient.Object, null, _defaultAnalyticsUri);
             const int numberOfCalls = 100000;
 
             // When 

--- a/Flagsmith.Client.Test/Fixtures.cs
+++ b/Flagsmith.Client.Test/Fixtures.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using FlagsmithEngine.Environment.Models;
@@ -10,7 +11,8 @@ namespace Flagsmith.FlagsmithClientTest
     {
         public static string ApiKey => "ser.test_key";
         public static string ApiUrl => "http://test_url/";
-        public static AnalyticsProcessorTest GetAnalyticalProcessorTest() => new(new HttpClient(), ApiKey, ApiUrl);
+        public static Uri AnalyticsUri => new Uri(ApiUrl + "analytics/flags/");
+        public static AnalyticsProcessorTest GetAnalyticalProcessorTest() => new(new HttpClient(), ApiKey, AnalyticsUri);
         public static JObject JsonObject = JObject.Parse(@"{
   'api_key': 'test_key',
   'name': 'Test Environment',

--- a/Flagsmith.Client.Test/UserAgentTest.cs
+++ b/Flagsmith.Client.Test/UserAgentTest.cs
@@ -113,7 +113,7 @@ namespace Flagsmith.FlagsmithClientTest
             var analyticsProcessor = new AnalyticsProcessor(
                 httpClientMock.Object,
                 Fixtures.ApiKey,
-                Fixtures.ApiUrl
+                Fixtures.AnalyticsUri
             );
 
             // When

--- a/Flagsmith.FlagsmithClient/AnalyticsProcessor.cs
+++ b/Flagsmith.FlagsmithClient/AnalyticsProcessor.cs
@@ -18,7 +18,7 @@ namespace Flagsmith
 
         private int _FlushIntervalSeconds = 10;
         private readonly DisposableLock _lock = new DisposableLock();
-        private readonly string _AnalyticsEndPoint;
+        private readonly Uri _AnalyticsUri;
         private readonly string _EnvironmentKey;
         private readonly int _TimeOut;
         private DateTime _LastFlushed;
@@ -28,9 +28,14 @@ namespace Flagsmith
         private ConcurrentDictionary<string, Dictionary<string, int>> AnalyticsDataThreads;
 
         public AnalyticsProcessor(HttpClient httpClient, string environmentKey, string baseApiUrl, ILogger logger = null, Dictionary<string, string> customHeaders = null, int timeOut = 3, int flushIntervalSeconds = 10)
+            : this(httpClient, environmentKey, new Uri(baseApiUrl + "analytics/flags/", UriKind.RelativeOrAbsolute), logger, customHeaders, timeOut, flushIntervalSeconds)
+        {
+        }
+
+        public AnalyticsProcessor(HttpClient httpClient, string environmentKey, Uri analyticsUri, ILogger logger = null, Dictionary<string, string> customHeaders = null, int timeOut = 3, int flushIntervalSeconds = 10)
         {
             _EnvironmentKey = environmentKey;
-            _AnalyticsEndPoint = baseApiUrl + "analytics/flags/";
+            _AnalyticsUri = analyticsUri;
             _TimeOut = timeOut;
             _LastFlushed = DateTime.UtcNow;
             _HttpClient = httpClient;
@@ -71,7 +76,7 @@ namespace Flagsmith
             try
             {
                 var analyticsJson = JsonConvert.SerializeObject(GetAggregatedAnalyticsWithoutLock());
-                var request = new HttpRequestMessage(HttpMethod.Post, _AnalyticsEndPoint)
+                var request = new HttpRequestMessage(HttpMethod.Post, _AnalyticsUri)
                 {
                     Headers =
                         {

--- a/Flagsmith.FlagsmithClient/FlagsmithClient.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithClient.cs
@@ -70,7 +70,7 @@ namespace Flagsmith
                     throw new Exception("ValueError: environmentKey is required");
                 }
                 if (_config.EnableAnalytics)
-                    _analyticsProcessor = new AnalyticsProcessor(_config.HttpClient, _config.EnvironmentKey, _config.ApiUri.ToString(), _config.Logger, _config.CustomHeaders);
+                    _analyticsProcessor = new AnalyticsProcessor(_config.HttpClient, _config.EnvironmentKey, _config.AnalyticsUri ?? new Uri(_config.ApiUri, "analytics/flags/"), _config.Logger, _config.CustomHeaders);
 
                 if (_config.EnableLocalEvaluation)
                 {

--- a/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
+++ b/Flagsmith.FlagsmithClient/FlagsmithConfiguration.cs
@@ -20,6 +20,14 @@ namespace Flagsmith
         public Uri ApiUri { get; set; } = DefaultApiUri;
 
         /// <summary>
+        /// URI of the Flagsmith analytics events API endpoint. Set this when analytics are not served by the same
+        /// API as flags, e.g. when using Edge Proxy. Defaults to the <c>analytics/flags/</c> endpoint relative to
+        /// <see cref="ApiUri"/>.
+        /// <example><code>new Uri("https://flagsmith.example.com/api/v1/analytics/flags/")</code></example>
+        /// </summary>
+        public Uri? AnalyticsUri { get; set; }
+
+        /// <summary>
         /// The environment key obtained from Flagsmith interface.
         /// </summary>
         public string EnvironmentKey { get; set; }


### PR DESCRIPTION
This PR ports [flagsmith-nodejs-client#168](https://github.com/Flagsmith/flagsmith-nodejs-client/pull/168) to the .NET client. It allows for the URL to which analytics data is posted to be changed from the default. This allows users to bypass the edge proxy for example, which doesn't support analytics. 